### PR TITLE
Attempt pipelines fix

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -128,7 +128,7 @@ jobs:
 
   - script: |
       call activate bw2
-      conda install --yes --quiet -c defaults -c conda-forge -c cmutel -c haasad --name bw2 python=%PYTHON_VERSION% pytest peewee brightway2 pytest pytest-azurepipelines pytest-cov win32
+      conda install --yes --quiet -c defaults -c conda-forge -c cmutel -c haasad --name bw2 python=%PYTHON_VERSION% pytest peewee brightway2 pytest pytest-azurepipelines pytest-cov pywin32
     displayName: Install Anaconda packages
 
   - script: |
@@ -154,7 +154,7 @@ jobs:
 
   - script: |
       call activate bw2
-      conda install --yes --quiet -c defaults -c conda-forge -c cmutel -c haasad --name bw2 python=%PYTHON_VERSION% pytest peewee brightway2 pytest pytest-azurepipelines pytest-cov=2.6.0 win32
+      conda install --yes --quiet -c defaults -c conda-forge -c cmutel -c haasad --name bw2 python=%PYTHON_VERSION% pytest peewee brightway2 pytest pytest-azurepipelines pytest-cov=2.6.0 pywin32
     displayName: Install Anaconda packages
 
   - script: |

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -19,12 +19,12 @@ jobs:
 
   - bash: |
       source activate bw2
-      conda install --yes --quiet -c defaults -c conda-forge -c cmutel -c haasad --name bw2 python=$PYTHON_VERSION peewee brightway2 pytest pytest-azurepipelines pytest-cov
+      conda install --yes --quiet -c defaults -c conda-forge -c cmutel -c haasad --name bw2 python=$PYTHON_VERSION peewee brightway2 pytest pytest-azurepipelines coverage
     displayName: Install Anaconda packages
 
   - bash: |
       source activate bw2
-      pytest --cov=bw2data
+      coverage run --source=bw2data -m pytest
     displayName: pytest
 
 - job:
@@ -45,13 +45,13 @@ jobs:
 
   - bash: |
       source activate bw2
-      conda install --yes --quiet -c defaults -c conda-forge -c cmutel -c haasad --name bw2 python=$PYTHON_VERSION peewee brightway2 pytest pytest-azurepipelines pytest-cov=2.6.0 pathlib
+      conda install --yes --quiet -c defaults -c conda-forge -c cmutel -c haasad --name bw2 python=$PYTHON_VERSION peewee brightway2 pytest pytest-azurepipelines coverage pathlib
     displayName: Install Anaconda packages
 
   - bash: |
       source activate bw2
       pwd
-      pytest --cov=bw2data
+      coverage run --source=bw2data -m pytest
     displayName: pytest
 
 - job:
@@ -74,12 +74,12 @@ jobs:
 
   - bash: |
       source activate bw2
-      conda install --yes --quiet -c defaults -c conda-forge -c cmutel -c haasad --name bw2 python=$PYTHON_VERSION peewee brightway2 pytest pytest-azurepipelines pytest-cov
+      conda install --yes --quiet -c defaults -c conda-forge -c cmutel -c haasad --name bw2 python=$PYTHON_VERSION peewee brightway2 pytest pytest-azurepipelines coverage
     displayName: Install Anaconda packages
 
   - bash: |
       source activate bw2
-      pytest --cov=bw2data
+      coverage run --source=bw2data -m pytest
     displayName: pytest
 
 - job:
@@ -100,12 +100,12 @@ jobs:
 
   - bash: |
       source activate bw2
-      conda install --yes --quiet -c defaults -c conda-forge -c cmutel -c haasad --name bw2 python=$PYTHON_VERSION peewee brightway2 pytest pytest-azurepipelines pytest-cov=2.6.0 pathlib
+      conda install --yes --quiet -c defaults -c conda-forge -c cmutel -c haasad --name bw2 python=$PYTHON_VERSION peewee brightway2 pytest pytest-azurepipelines coverage pathlib
     displayName: Install Anaconda packages
 
   - bash: |
       source activate bw2
-      pytest --cov=bw2data
+      coverage run --source=bw2data -m pytest
     displayName: pytest
 
 - job:
@@ -128,12 +128,12 @@ jobs:
 
   - script: |
       call activate bw2
-      conda install --yes --quiet -c defaults -c conda-forge -c cmutel -c haasad --name bw2 python=%PYTHON_VERSION% peewee brightway2 pytest pytest-azurepipelines pytest-cov pywin32
+      conda install --yes --quiet -c defaults -c conda-forge -c cmutel -c haasad --name bw2 python=%PYTHON_VERSION% peewee brightway2 pytest pytest-azurepipelines coverage pywin32
     displayName: Install Anaconda packages
 
   - script: |
       call activate bw2
-      pytest --cov=bw2data
+      coverage run --source=bw2data -m pytest
     displayName: pytest
 
 - job:
@@ -154,10 +154,10 @@ jobs:
 
   - script: |
       call activate bw2
-      conda install --yes --quiet -c defaults -c conda-forge -c cmutel -c haasad --name bw2 python=%PYTHON_VERSION% peewee brightway2 pytest pytest-azurepipelines pytest-cov=2.6.0 pywin32 pathlib
+      conda install --yes --quiet -c defaults -c conda-forge -c cmutel -c haasad --name bw2 python=%PYTHON_VERSION% peewee brightway2 pytest pytest-azurepipelines coverage pywin32 pathlib
     displayName: Install Anaconda packages
 
   - script: |
       call activate bw2
-      pytest --cov=bw2data
+      coverage run --source=bw2data -m pytest
     displayName: pytest

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -53,6 +53,8 @@ jobs:
       pwd
       coverage run --source=bw2data -m pytest
     displayName: pytest
+    env:
+      PYTHONIOENCODING: 'utf-8'
 
 - job:
   displayName: macOS-10.14-38
@@ -107,6 +109,8 @@ jobs:
       source activate bw2
       coverage run --source=bw2data -m pytest
     displayName: pytest
+    env:
+      PYTHONIOENCODING: 'utf-8'
 
 - job:
   displayName: vs2017-win2016-38
@@ -161,3 +165,5 @@ jobs:
       call activate bw2
       coverage run --source=bw2data -m pytest
     displayName: pytest
+    env:
+      PYTHONIOENCODING: 'utf-8'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -19,7 +19,7 @@ jobs:
 
   - bash: |
       source activate bw2
-      conda install --yes --quiet -c defaults -c conda-forge -c cmutel -c haasad --name bw2 python=$PYTHON_VERSION pytest peewee brightway2 pytest pytest-azurepipelines pytest-cov
+      conda install --yes --quiet -c defaults -c conda-forge -c cmutel -c haasad --name bw2 python=$PYTHON_VERSION peewee brightway2 pytest pytest-azurepipelines pytest-cov
     displayName: Install Anaconda packages
 
   - bash: |
@@ -45,7 +45,7 @@ jobs:
 
   - bash: |
       source activate bw2
-      conda install --yes --quiet -c defaults -c conda-forge -c cmutel -c haasad --name bw2 python=$PYTHON_VERSION pytest peewee brightway2 pytest pytest-azurepipelines pytest-cov=2.6.0 pathlib
+      conda install --yes --quiet -c defaults -c conda-forge -c cmutel -c haasad --name bw2 python=$PYTHON_VERSION peewee brightway2 pytest pytest-azurepipelines pytest-cov=2.6.0 pathlib
     displayName: Install Anaconda packages
 
   - bash: |
@@ -74,7 +74,7 @@ jobs:
 
   - bash: |
       source activate bw2
-      conda install --yes --quiet -c defaults -c conda-forge -c cmutel -c haasad --name bw2 python=$PYTHON_VERSION pytest peewee brightway2 pytest pytest-azurepipelines pytest-cov
+      conda install --yes --quiet -c defaults -c conda-forge -c cmutel -c haasad --name bw2 python=$PYTHON_VERSION peewee brightway2 pytest pytest-azurepipelines pytest-cov
     displayName: Install Anaconda packages
 
   - bash: |
@@ -100,7 +100,7 @@ jobs:
 
   - bash: |
       source activate bw2
-      conda install --yes --quiet -c defaults -c conda-forge -c cmutel -c haasad --name bw2 python=$PYTHON_VERSION pytest peewee brightway2 pytest pytest-azurepipelines pytest-cov=2.6.0 pathlib
+      conda install --yes --quiet -c defaults -c conda-forge -c cmutel -c haasad --name bw2 python=$PYTHON_VERSION peewee brightway2 pytest pytest-azurepipelines pytest-cov=2.6.0 pathlib
     displayName: Install Anaconda packages
 
   - bash: |
@@ -128,7 +128,7 @@ jobs:
 
   - script: |
       call activate bw2
-      conda install --yes --quiet -c defaults -c conda-forge -c cmutel -c haasad --name bw2 python=%PYTHON_VERSION% pytest peewee brightway2 pytest pytest-azurepipelines pytest-cov pywin32
+      conda install --yes --quiet -c defaults -c conda-forge -c cmutel -c haasad --name bw2 python=%PYTHON_VERSION% peewee brightway2 pytest pytest-azurepipelines pytest-cov pywin32
     displayName: Install Anaconda packages
 
   - script: |
@@ -154,7 +154,7 @@ jobs:
 
   - script: |
       call activate bw2
-      conda install --yes --quiet -c defaults -c conda-forge -c cmutel -c haasad --name bw2 python=%PYTHON_VERSION% pytest peewee brightway2 pytest pytest-azurepipelines pytest-cov=2.6.0 pywin32 pathlib
+      conda install --yes --quiet -c defaults -c conda-forge -c cmutel -c haasad --name bw2 python=%PYTHON_VERSION% peewee brightway2 pytest pytest-azurepipelines pytest-cov=2.6.0 pywin32 pathlib
     displayName: Install Anaconda packages
 
   - script: |

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -45,7 +45,7 @@ jobs:
 
   - bash: |
       source activate bw2
-      conda install --yes --quiet -c defaults -c conda-forge -c cmutel -c haasad --name bw2 python=$PYTHON_VERSION pytest peewee brightway2 pytest pytest-azurepipelines pytest-cov=2.6.0
+      conda install --yes --quiet -c defaults -c conda-forge -c cmutel -c haasad --name bw2 python=$PYTHON_VERSION pytest peewee brightway2 pytest pytest-azurepipelines pytest-cov=2.6.0 pathlib
     displayName: Install Anaconda packages
 
   - bash: |
@@ -100,7 +100,7 @@ jobs:
 
   - bash: |
       source activate bw2
-      conda install --yes --quiet -c defaults -c conda-forge -c cmutel -c haasad --name bw2 python=$PYTHON_VERSION pytest peewee brightway2 pytest pytest-azurepipelines pytest-cov=2.6.0
+      conda install --yes --quiet -c defaults -c conda-forge -c cmutel -c haasad --name bw2 python=$PYTHON_VERSION pytest peewee brightway2 pytest pytest-azurepipelines pytest-cov=2.6.0 pathlib
     displayName: Install Anaconda packages
 
   - bash: |
@@ -154,7 +154,7 @@ jobs:
 
   - script: |
       call activate bw2
-      conda install --yes --quiet -c defaults -c conda-forge -c cmutel -c haasad --name bw2 python=%PYTHON_VERSION% pytest peewee brightway2 pytest pytest-azurepipelines pytest-cov=2.6.0 pywin32
+      conda install --yes --quiet -c defaults -c conda-forge -c cmutel -c haasad --name bw2 python=%PYTHON_VERSION% pytest peewee brightway2 pytest pytest-azurepipelines pytest-cov=2.6.0 pywin32 pathlib
     displayName: Install Anaconda packages
 
   - script: |

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -45,7 +45,7 @@ jobs:
 
   - bash: |
       source activate bw2
-      conda install --yes --quiet -c defaults -c conda-forge -c cmutel -c haasad --name bw2 python=$PYTHON_VERSION peewee brightway2 pytest pytest-azurepipelines coverage pathlib
+      conda install --yes --quiet -c defaults -c conda-forge -c cmutel -c haasad --name bw2 python=$PYTHON_VERSION peewee brightway2 "pytest>3.2.2" pytest-azurepipelines coverage pathlib
     displayName: Install Anaconda packages
 
   - bash: |
@@ -102,7 +102,7 @@ jobs:
 
   - bash: |
       source activate bw2
-      conda install --yes --quiet -c defaults -c conda-forge -c cmutel -c haasad --name bw2 python=$PYTHON_VERSION peewee brightway2 pytest pytest-azurepipelines coverage pathlib
+      conda install --yes --quiet -c defaults -c conda-forge -c cmutel -c haasad --name bw2 python=$PYTHON_VERSION peewee brightway2 "pytest>3.2.2" pytest-azurepipelines coverage pathlib
     displayName: Install Anaconda packages
 
   - bash: |
@@ -158,7 +158,7 @@ jobs:
 
   - script: |
       call activate bw2
-      conda install --yes --quiet -c defaults -c conda-forge -c cmutel -c haasad --name bw2 python=%PYTHON_VERSION% peewee brightway2 pytest pytest-azurepipelines coverage pywin32 pathlib
+      conda install --yes --quiet -c defaults -c conda-forge -c cmutel -c haasad --name bw2 python=%PYTHON_VERSION% peewee brightway2 "pytest>3.2.2" pytest-azurepipelines coverage pywin32 pathlib
     displayName: Install Anaconda packages
 
   - script: |


### PR DESCRIPTION
A partial fix of the `azure-pipelines.yml` configuration. The [old pull-request](https://github.com/brightway-lca/brightway2-data/pull/2) shows that only the ubuntu 2.7 machine was still failing.