### PR TITLE
fix __eq__ for Exchange

### DIFF
--- a/bw2data/proxies.py
+++ b/bw2data/proxies.py
@@ -131,6 +131,12 @@ class ExchangeProxyBase(ProxyBase):
                 other.output.key,
             )
 
+    def __eq__(self, other):
+        return self._data == other
+
+    def __hash__(self):
+        return hash(self._data.__str__())
+
     def _get_input(self):
         """Get or set the exchange input.
 

--- a/tests/exchange_proxy.py
+++ b/tests/exchange_proxy.py
@@ -339,3 +339,12 @@ def test_delete_parameterized_exchange():
     exc.delete()
     assert ActivityParameter.select().count() == 2
     assert not ParameterizedExchange.select().count()
+
+
+def test_exchange_eq(activity):
+    ex = list(activity.exchanges())[0]
+    assert ex == ex
+
+def test_exchange_hash(activity):
+    ex = list(activity.exchanges())[0]
+    assert ex.__hash__()


### PR DESCRIPTION
Problem: comparing two exchanges yields an exception: `AttributeError: 'Activity' object has no attribute '_dict'`
Solution: implement `__eq__` for exchanges
Addon: also implemented `__hash__`

Requesting review by @cmutel 