### PR TITLE
check for `numbers.Integral` in `bw2data.utils.get_activity`

### DIFF
--- a/bw2data/utils.py
+++ b/bw2data/utils.py
@@ -1,5 +1,6 @@
 import collections
 import itertools
+import numbers
 import os
 import random
 import re
@@ -440,7 +441,7 @@ def get_activity(key=None, **kwargs):
     elif isinstance(key, tuple):
         kwargs["database"] = key[0]
         kwargs["code"] = key[1]
-    elif isinstance(key, int):
+    elif isinstance(key, numbers.Integral):
         kwargs["id"] = key
     return get_node(**kwargs)
 

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,5 +1,6 @@
 import pytest
 import stats_arrays as sa
+import numpy as np
 
 from bw2data import Database, Method, methods
 from bw2data.backends import Activity as PWActivity
@@ -244,6 +245,23 @@ def test_get_activity_id():
     node = get_activity(1)
     assert node.id == 1
     assert isinstance(node, PWActivity)
+
+
+@bw2test
+def test_get_activity_id_different_ints():
+    Database("biosphere").write(biosphere)
+    different_ints = [
+        int(1),
+        np.int0(1),
+        np.int8(1),
+        np.int16(1),
+        np.int32(1),
+        np.int64(1),
+    ]
+    for i in different_ints:
+        node = get_activity(i)
+        assert node.id == i
+        assert isinstance(node, PWActivity)
 
 
 @bw2test


### PR DESCRIPTION
Check for `numbers.Integral` in `bw2data.utils.get_activity` instead of `int` to correctly handle other integer types, e.g. `numpy.int32`.