### PR TITLE
Implement cached method Database.to_dataframe

### DIFF
--- a/bw2data/backends/base.py
+++ b/bw2data/backends/base.py
@@ -8,7 +8,7 @@ import sqlite3
 import warnings
 from collections import defaultdict
 
-import pandas
+import pandas as pd
 import pyprind
 from bw_processing import clean_datapackage_name, create_datapackage
 from fs.zipfs import ZipFS
@@ -777,7 +777,7 @@ class SQLiteBackend(ProcessedDataStore):
             ),
         )
         if csv:
-            df = pandas.DataFrame([get_csv_data_dict(ds) for ds in self])
+            df = pd.DataFrame([get_csv_data_dict(ds) for ds in self])
             dp.add_csv_metadata(
                 dataframe=df,
                 valid_for=[

--- a/bw2data/backends/base.py
+++ b/bw2data/backends/base.py
@@ -1,5 +1,6 @@
 import copy
 import datetime
+from functools import lru_cache
 import itertools
 import pickle
 import pprint
@@ -285,6 +286,13 @@ class SQLiteBackend(ProcessedDataStore):
         del databases[old_name]
         self.name = name
         return new_db
+
+    @lru_cache(maxsize=5, typed=False)
+    def to_dataframe(self) -> pd.DataFrame:
+        """
+        Converts the database into a dataframe with one row per activity and one column per property / database field.
+        """
+        return pd.DataFrame(self)
 
     ### Iteration, filtering, and ordering
     ######################################

--- a/bw2data/database.py
+++ b/bw2data/database.py
@@ -1,9 +1,11 @@
 from . import databases
 from .backends import SQLiteBackend
 from .backends.iotable import IOTableBackend
+from functools import lru_cache
 from typing import Union, Optional
 
 
+@lru_cache(maxsize=5, typed=False)
 def DatabaseChooser(
     name: str, backend: Optional[str] = None
 ) -> Union[SQLiteBackend, IOTableBackend]:

--- a/bw2data/database.py
+++ b/bw2data/database.py
@@ -1,9 +1,12 @@
 from . import databases
 from .backends import SQLiteBackend
 from .backends.iotable import IOTableBackend
+from typing import Union, Optional
 
 
-def DatabaseChooser(name, backend=None):
+def DatabaseChooser(
+    name: str, backend: Optional[str] = None
+) -> Union[SQLiteBackend, IOTableBackend]:
     """A method that returns a database class instance.
 
     Database types are specified in `databases[database_name]['backend']`.

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -125,3 +125,12 @@ get_naughty = lambda: [
     )
     if x[0] != "#"
 ]
+
+large_database = {
+    ("large db", str(i)): {
+        "name": f"name {i}",
+        "location": f"location {i}",
+        "reference product": f"product {i}",
+    }
+    for i in range(1000)
+}


### PR DESCRIPTION
Implements a cached helper method `to_dataframe()` for `SQLiteBackend` (and hence also for the `IOTable` backend, because of inheritance). Uses standard `functools.lru_cache` with a size of 5. Would be neat to have for https://github.com/brightway-lca/brightway2-analyzer/pull/16.

Requesting review by @cmutel.

# Speed improvement
On my machine, the improvement is approx. 8-fold. Using `get_labeled_inventory` from the corresponding `bw2analyzer` branch:

```python
method = ('EF v3.0', 'climate change', 'global warming potential (GWP100)')
act = ("apos371", "2008044abc9469af9dee29707db7f8fb") # market for waste packaging paper
lca = LCA({act:1}, method)
lca.lci()

t_start = time()
df = get_labeled_inventory(lca, wide_format=True)
print(f"Elapsed time: {time()-t_start}") # Elapsed time: 3.068533182144165
t_start = time()
df = get_labeled_inventory(lca, wide_format=True) # Elapsed time: 0.39063262939453125
print(f"Elapsed time: {time()-t_start}")
```

# Memory usage
Ecoinvent 3.7.1 APOS takes approximately 60 MB of RAM. Assuming a user would call `Database(name).to_dataframe()` on five different ecoinvent versions, the total cache size would be 5x60 = 300 MB. On the next call to a new database, the first entry from the cache would be dropped, so memory usage would stay constant.