### PR TITLE
Nox config to install test requirements and use pytests to run tests

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -1,0 +1,7 @@
+import nox
+
+
+@nox.session
+def tests(session):
+    session.install("-r", "requirements-test.txt")
+    session.run("pytest")


### PR DESCRIPTION
`nox` has to be present on the system to run the tests. I followed [introduction](https://nox.thea.codes/en/stable/index.html) documentation to setup `nox`. After that, using `nox` command would run all the tests.

related #100