### PR TITLE
Remove redundant setting of dataset, already being done in create_project

### DIFF
--- a/bw2data/project.py
+++ b/bw2data/project.py
@@ -172,11 +172,8 @@ class ProjectManager(Iterable):
         # for new metadata stores
         self.read_only = False
         self.create_project(name)
-        self.dataset = ProjectDataset.get(ProjectDataset.name == self._project_name)
         self._reset_meta()
         self._reset_sqlite3_databases()
-
-        self.dataset = ProjectDataset.get(name=name)
 
         if not lockable():
             pass


### PR DESCRIPTION
`create_project` already has the logic of setting `self.dataset` and these explicit instructions are redundant.