### PR TITLE
Backport #128 to fix #127 on bw2legacy

### DIFF
--- a/bw2data/backends/peewee/database.py
+++ b/bw2data/backends/peewee/database.py
@@ -214,6 +214,10 @@ class SQLiteBackend(LCIBackend):
             if exchanges:
                 ExchangeDataset.insert_many(exchanges).execute()
             sqlite3_lci_db.db.commit()
+            if len(self) > 500:
+                sqlite3_lci_db.vacuum()
+
+
         except:
             sqlite3_lci_db.db.rollback()
             raise
@@ -327,8 +331,6 @@ class SQLiteBackend(LCIBackend):
             """
             warnings.warn(MESSAGE.format(self.name), UserWarning)
 
-        vacuum_needed = len(self) > 500
-
         ActivityDataset.delete().where(ActivityDataset.database== self.name).execute()
         ExchangeDataset.delete().where(ExchangeDataset.output_database== self.name).execute()
         IndexManager(self.filename).delete_database()
@@ -344,9 +346,6 @@ class SQLiteBackend(LCIBackend):
                 ParameterizedExchange.group << groups).execute()
             ActivityParameter.delete().where(ActivityParameter.database == self.name).execute()
             DatabaseParameter.delete().where(DatabaseParameter.database == self.name).execute()
-
-        if vacuum_needed:
-            sqlite3_lci_db.vacuum()
 
     def process(self):
         """


### PR DESCRIPTION
Hi, I got the same issue as in #127 but in the `bw2legacy` branch.  So this is a backport of #128 onto `bw2legacy`.

```
Traceback (most recent call last):
(...)
  File "/opt/conda/lib/python3.9/site-packages/bw2data/backends/peewee/database.py", line 260, in write
    self._efficient_write_many_data(data)
  File "/opt/conda/lib/python3.9/site-packages/bw2data/backends/peewee/database.py", line 193, in _efficient_write_many_data
    self.delete(keep_params=True, warn=False)
  File "/opt/conda/lib/python3.9/site-packages/bw2data/project.py", line 358, in writable_project
    return wrapped(*args, **kwargs)
  File "/opt/conda/lib/python3.9/site-packages/bw2data/backends/peewee/database.py", line 349, in delete
    sqlite3_lci_db.vacuum()
  File "/opt/conda/lib/python3.9/site-packages/bw2data/sqlite.py", line 57, in vacuum
    self.execute_sql('VACUUM;')
  File "/opt/conda/lib/python3.9/site-packages/bw2data/sqlite.py", line 50, in execute_sql
    return self.db.execute_sql(*args, **kwargs)
  File "/opt/conda/lib/python3.9/site-packages/peewee.py", line 3236, in execute_sql
    cursor.execute(sql, params or ())
  File "/opt/conda/lib/python3.9/site-packages/peewee.py", line 3010, in __exit__
    reraise(new_type, new_type(exc_value, *exc_args), traceback)
  File "/opt/conda/lib/python3.9/site-packages/peewee.py", line 192, in reraise
    raise value.with_traceback(tb)
  File "/opt/conda/lib/python3.9/site-packages/peewee.py", line 3236, in execute_sql
    cursor.execute(sql, params or ())
peewee.OperationalError: cannot VACUUM from within a transaction
```