### PR TITLE
search method in the base class

### DIFF
--- a/bw2data/backends/base.py
+++ b/bw2data/backends/base.py
@@ -202,6 +202,9 @@ class LCIBackend(ProcessedDataStore):
         """
         raise NotImplementedError
 
+    def search(self, *args, **kwargs):
+        raise NotImplementedError
+
     def process(self, *args, **kwargs):
         """
 Process inventory documents.


### PR DESCRIPTION
Hi,
Fixing things as I see them, I have a minor Pyright error that says `Cannot access member "search" for type "SingleFileDatabase".   Member "search" is unknown (Pyright reportGeneralTypeIssues)`. 
That's because the `search` method is only implemented in SQLiteBackend. So adding it in the base class as unimplemented makes the linter happy.