### PR TITLE
is_test does not exist in production

### DIFF
--- a/bw2data/backends/base.py
+++ b/bw2data/backends/base.py
@@ -459,7 +459,7 @@ class SQLiteBackend(ProcessedDataStore):
             exchanges, activities = [], []
 
             for index, (key, ds) in enumerate(
-                tqdm_wrapper(data.items(), getattr(config, "is_test"))
+                tqdm_wrapper(data.items(), getattr(config, "is_test", False))
             ):
                 exchanges, activities = self._efficient_write_dataset(
                     index, key, ds, exchanges, activities


### PR DESCRIPTION
The `is_test` attribute works in the tests, not in production:

```
Traceback (most recent call last):
  File "/home/jovyan/ecobalyse/data/import_agribalyse.py", line 281, in <module>
    main()
  File "/home/jovyan/ecobalyse/data/import_agribalyse.py", line 275, in main
    import_agribalyse()
  File "/home/jovyan/ecobalyse/data/import_agribalyse.py", line 183, in import_agribalyse
    agribalyse.add_unlinked_flows_to_biosphere_database(biosphere)
  File "/opt/conda/lib/python3.11/site-packages/bw2io/importers/base_lci.py", line 420, in add_unlinked_flows_to_biosphere_database
    bio.write(data)
  File "/opt/conda/lib/python3.11/site-packages/bw2data/backends/base.py", line 522, in write
    self._efficient_write_many_data(data)
  File "/opt/conda/lib/python3.11/site-packages/bw2data/backends/base.py", line 462, in _efficient_write_many_data
    tqdm_wrapper(data.items(), getattr(config, "is_test"))
                               ^^^^^^^^^^^^^^^^^^^^^^^^^^
AttributeError: 'Config' object has no attribute 'is_test'
```