### PR TITLE
Replace `requests` with `urllib`

### DIFF
--- a/bw2data/logs.py
+++ b/bw2data/logs.py
@@ -88,18 +88,6 @@ Message:
     return logger
 
 
-def upload_logs_to_server(metadata={}):
-    # Hardcoded for now
-    url = "http://reports.brightway.dev/logs"
-    zip_fo = create_in_memory_zipfile_from_directory(projects.logs_dir)
-    files = {"file": (uuid.uuid4().hex + ".zip", zip_fo.read())}
-    metadata["json"] = "native" if anyjson is None else anyjson.implementation.name
-    metadata["windows"] = config._windows
-    data = urllib.parse.urlencode(metadata).encode('utf-8')
-    req = urllib.request.Request(url, data=data, files=files)
-    response = urllib.request.urlopen(req)
-    return response.read()
-
 
 def close_log(log):
     """Detach log handlers; flush to disk"""

--- a/bw2data/logs.py
+++ b/bw2data/logs.py
@@ -4,7 +4,6 @@ import logging
 import uuid
 from logging.handlers import RotatingFileHandler
 
-import requests
 
 from . import config, projects
 from .utils import create_in_memory_zipfile_from_directory, random_string
@@ -96,7 +95,10 @@ def upload_logs_to_server(metadata={}):
     files = {"file": (uuid.uuid4().hex + ".zip", zip_fo.read())}
     metadata["json"] = "native" if anyjson is None else anyjson.implementation.name
     metadata["windows"] = config._windows
-    return requests.post(url, data=metadata, files=files)
+    data = urllib.parse.urlencode(metadata).encode('utf-8')
+    req = urllib.request.Request(url, data=data, files=files)
+    response = urllib.request.urlopen(req)
+    return response.read()
 
 
 def close_log(log):

--- a/bw2data/utils.py
+++ b/bw2data/utils.py
@@ -296,7 +296,7 @@ def download_file(filename, directory="downloads", url=None):
 
     assert isinstance(directory, str), "`directory` must be a string"
     dirpath = projects.request_directory(directory)
-    filepath = os.path.join(dirpath, filename)
+    filepath = dirpath / filename
     download_path = (url if url is not None else DOWNLOAD_URL) + filename
     with urllib.request.urlopen(download_path) as response, open(filepath, 'wb') as out_file:
         if response.status != 200:
@@ -310,30 +310,6 @@ def download_file(filename, directory="downloads", url=None):
                 break
             out_file.write(segment)
     return filepath
-
-
-def web_ui_accessible():
-    """Test if ``bw2-web`` is running and accessible. Returns ``True`` or ``False``."""
-    base_url = config.p.get("web_ui_address", "http://127.0.0.1:5000") + "/ping"
-    try:
-        response = urllib.request.urlopen(base_url)
-    except urllib.error.URLError:
-        return False
-    return response.read().decode('utf-8') == "pong"
-
-def open_activity_in_webbrowser(activity):
-    """Open a dataset document in the Brightway2 web UI. Requires ``bw2-web`` to be running.
-
-    ``activity`` is a dataset key, e.g. ``("foo", "bar")``."""
-    base_url = config.p.get("web_ui_address", "http://127.0.0.1:5000")
-    if not web_ui_accessible():
-        raise WebUIError("Can't find bw2-web UI (tried %s)" % base_url)
-    url = base_url + "/view/%s/%s" % (
-        urllib.quote(activity[0]),
-        urllib.quote(activity[1]),
-    )
-    webbrowser.open_new_tab(url)
-    return url
 
 
 def set_data_dir(dirpath, permanent=True):

--- a/setup.cfg
+++ b/setup.cfg
@@ -55,7 +55,6 @@ install_requires =
     numpy
     peewee >=3.9.4
     platformdirs
-    requests >=1.1.0
     scipy
     stats_arrays
     tqdm


### PR DESCRIPTION
Related:

 - https://github.com/brightway-lca/brightway-hub/issues/26
 - https://github.com/jupyterlite/xeus-python-kernel/issues/148#issuecomment-1691199688

The `pysocks` package feedstock uses virtual packages, which causes an issue during the JupyterLite build process. Since there are only two functions that use `requests`, we _could_ replace them with the Python library `urllib`. This is just a PoC at this point.