### PR TITLE
Resolve "Too Many Open Files" Error by Managing ZipFS Resources

### DIFF
--- a/bw2data/data_store.py
+++ b/bw2data/data_store.py
@@ -161,7 +161,9 @@ class ProcessedDataStore(DataStore):
         return self.dirpath_processed() / self.filename_processed()
 
     def datapackage(self):
-        return load_datapackage(ZipFS(self.filepath_processed()))
+        zip_file_path = self.filepath_processed()
+        with ZipFS(zip_file_path) as zip_fs:
+            return load_datapackage(zip_fs)
 
     def write(self, data, process=True):
         """Serialize intermediate data to disk.


### PR DESCRIPTION
I've modified the datapackage method to ensure proper management of ZipFS resources. The change involves using a with statement to handle the opening and closing of ZipFS instances. This aims to resolve the "Too Many Open Files" error encountered during extensive operations, such as Monte Carlo simulations in LCA calculations.

Modified code

```python
  def datapackage(self):
        return load_datapackage(ZipFS(self.filepath_processed()))
```
to
```python
def datapackage(self):
    zip_file_path = self.filepath_processed()
    with ZipFS(zip_file_path) as zip_fs:
        return load_datapackage(zip_fs)
```
I conducted an extensive manual testing process rather than traditional unit testing.
I ran various LCA calculations using the entire library to validate the integrity and functionality of the modified method.
The tests confirmed that the "Too Many Open Files" error was resolved without impacting the performance or output.

#157 