### PR TITLE
Fix a type error in ProjectManager's report() function

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -14,3 +14,13 @@ It is part of the `Brightway LCA framework <https://brightway.dev>`_.
 `Online documentation <https://docs.brightway.dev/>`_ is available, and the source code is hosted on `GitHub brightway-lca organization <https://github.com/brightway-lca/brightway2-data>`_.
 
 Note that version 4.0 and higher are only compatible with Brightway 2.5, as described in the `changelog <https://github.com/brightway-lca/brightway2-data/blob/main/CHANGES.md>`__.
+
+
+## Development Setup
+
+```bash
+brightway2-data $ python3 -m venv venv
+brightway2-data $ source ./venv/bin/activate
+brightway2-data $ python3 -m pip install -r requirements-test.txt
+brightway2-data $ pytest
+```

--- a/bw2data/project.py
+++ b/bw2data/project.py
@@ -363,7 +363,7 @@ class ProjectManager(Iterable):
 
             Does not follow symbolic links"""
             return sum(
-                sum(os.path.getsize(root / name) for name in files)
+                sum(os.path.getsize(Path(root) / name) for name in files)
                 for root, dirs, files in os.walk(dirpath)
             )
 

--- a/tests/projects.py
+++ b/tests/projects.py
@@ -130,7 +130,9 @@ def test_funny_project_names():
 
 @bw2test
 def test_report():
-    assert projects.report
+    projects.set_current("foo")
+    report = projects.report()
+    assert "foo" in [name for (name, _, _) in report]
 
 
 @bw2test


### PR DESCRIPTION
I wanted to introspect the state of my `ProjectManager` via `bw2data.projects.report()` as recommended in `ProjectManager#__repr__()`, but I hit the following error.
```
    sum(os.path.getsize(root / name) for name in files)
TypeError: unsupported operand type(s) for /: 'str' and 'str'
```
Looks like a pretty straightforward issue of using pathlib operators where actually we have strings. I've switched to use `Path()` and updated `test_report` to a minimum characterization test that runs the function.

I've also added the steps I took to get the environment off the ground to the README, since it wasn't clear (maybe it would be obvious to a more practiced python developer). Feel free to omit that if it's inappropriate or incorrect.