### PR TITLE
add include_substitution option to technosphere()

### DIFF
--- a/bw2data/backends/proxies.py
+++ b/bw2data/backends/proxies.py
@@ -398,8 +398,11 @@ class Activity(ActivityProxyBase):
     def edges(self):
         return self.exchanges()
 
-    def technosphere(self):
-        return Exchanges(self.key, kinds=labels.technosphere_negative_edge_types)
+    def technosphere(self, include_substitution=False):
+        kinds = labels.technosphere_negative_edge_types
+        if include_substitution:
+            kinds = kinds + labels.substitution_edge_types
+        return Exchanges(self.key, kinds=kinds)
 
     def biosphere(self):
         return Exchanges(


### PR DESCRIPTION
This adds the option to include substitution exchanges in Activity.technosphere(). There is a similar option already for Activity.production(), but if one wants to (e.g. temporally) remap activities, it can be useful to treat substitution exchanges like technosphere exchanges. 

We came across this when investigating https://github.com/brightway-lca/bw_timex/issues/53 and found this a possibly useful addition in general