### PR TITLE
add check_typos to IOTableBackend write function

### DIFF
--- a/bw2data/backends/iotable/backend.py
+++ b/bw2data/backends/iotable/backend.py
@@ -22,8 +22,8 @@ class IOTableBackend(SQLiteBackend):
     backend = "iotable"
     node_class = IOTableActivity
 
-    def write(self, data, process=False, searchable=True):
-        super().write(data, process=False, searchable=searchable)
+    def write(self, data, process=False, searchable=True, check_typos=True):
+        super().write(data, process=process, searchable=searchable, check_typos=check_typos)
 
     def write_exchanges(self, technosphere, biosphere, dependents):
         """

--- a/bw2data/backends/iotable/backend.py
+++ b/bw2data/backends/iotable/backend.py
@@ -23,7 +23,7 @@ class IOTableBackend(SQLiteBackend):
     node_class = IOTableActivity
 
     def write(self, data, process=False, searchable=True, check_typos=True):
-        super().write(data, process=process, searchable=searchable, check_typos=check_typos)
+        super().write(data, process=False, searchable=searchable, check_typos=check_typos)
 
     def write_exchanges(self, technosphere, biosphere, dependents):
         """


### PR DESCRIPTION
This adds the "check_typos" argument to the IOTableBackend. Also, the "process" argument was not passed on before. 

Background: I wanted to write databases via premise, which use the IOTableBackend, and got this error:
<img width="1136" alt="image" src="https://github.com/brightway-lca/brightway2-data/assets/90762029/7de9204f-10d4-43d4-8d9f-0e8f8d595159">
