### PR TITLE
fix un-hashable error

### DIFF
--- a/bw2data/method.py
+++ b/bw2data/method.py
@@ -56,7 +56,7 @@ class Method(ImpactAssessmentDataStore):
         except UnknownObject:
             raise UnknownObject(
                 "Can't find flow `{}`, specified in CF row `{}` for method `{}`".format(
-                    {row[0]}, row, self.name
+                    {tuple(row[0]) if isinstance(row[0], list) else row[0]}, row, self.name
                 )
             )
         except KeyError:


### PR DESCRIPTION
found while fixing errors for AB.
`row[0]` can be either a key or a list which points to a database/code. In the second case will cause un-hashable error