### PR TITLE
Make `rapidfuzz` optional on `sys_platform=emscripten`

### DIFF
--- a/bw2data/backends/typos.py
+++ b/bw2data/backends/typos.py
@@ -11,6 +11,8 @@ try:
 except ImportError:
     # Can happen on Windows, see
     # https://github.com/rapidfuzz/RapidFuzz/tree/main?tab=readme-ov-file#with-pip
+    # Rapidfuzz is not currently available on Emscripten
+    # https://github.com/brightway-lca/brightway-live/issues/59
     from ..string_distance import damerau_levenshtein
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,7 +39,7 @@ dependencies = [
     "peewee>=3.9.4",
     "platformdirs",
     "pydantic-settings",
-    "rapidfuzz",
+    "rapidfuzz, sys_platform != 'emscripten'",
     "scipy",
     "stats_arrays",
     "tqdm",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,7 +39,7 @@ dependencies = [
     "peewee>=3.9.4",
     "platformdirs",
     "pydantic-settings",
-    "rapidfuzz, sys_platform != 'emscripten'",
+    "rapidfuzz; sys_platform != 'emscripten'",
     "scipy",
     "stats_arrays",
     "tqdm",


### PR DESCRIPTION
...until:

 - https://github.com/brightway-lca/brightway-live/issues/59

is ready, this would fix:

 - https://github.com/brightway-lca/brightway-live/issues/60
 - https://github.com/brightway-lca/brightway-live/issues/57
