### PR TITLE
Add basic blinker signals

### DIFF
--- a/bw2data/signals.py
+++ b/bw2data/signals.py
@@ -1,0 +1,20 @@
+from blinker import signal
+
+
+project_changed = signal('bw2data.project_changed', doc="""
+Emitted when project changed, after redirecting any SQLite database references.
+
+Expected inputs:
+    * `bw2data.projects.ProjectDataset` instance
+
+No expected return value.
+""")
+
+project_created = signal('bw2data.project_created', doc="""
+Emitted when project created, but before switching to that project, and before any filesystem ops.
+
+Expected inputs:
+    * `bw2data.projects.ProjectDataset` instance
+
+No expected return value.
+""")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,8 +29,7 @@ classifiers = [
 ]
 requires-python = ">=3.9"
 dependencies = [
-    # dependencies as strings with quotes, e.g. "foo"
-    # You can add version requirements like "foo>2.0"
+    "blinker",
     "bw2parameters",
     "bw_processing>=0.9.5",
     "fsspec",

--- a/tests/test_signals.py
+++ b/tests/test_signals.py
@@ -1,0 +1,28 @@
+from bw2data.project import ProjectDataset, projects
+from bw2data.tests import bw2test
+from blinker import signal
+
+
+class SignalCatcher:
+    def __call__(self, arg):
+        self.arg = arg
+
+
+@bw2test
+def test_project_changed_signal():
+    subscriber = SignalCatcher()
+    signal('bw2data.project_changed').connect(subscriber)
+    projects.set_current("foo")
+
+    assert isinstance(subscriber.arg, ProjectDataset)
+    assert subscriber.arg.name == 'foo'
+
+
+@bw2test
+def test_project_created_signal():
+    subscriber = SignalCatcher()
+    signal('bw2data.project_created').connect(subscriber)
+    projects.set_current("foo")
+
+    assert isinstance(subscriber.arg, ProjectDataset)
+    assert subscriber.arg.name == 'foo'


### PR DESCRIPTION
Used [blinker](https://github.com/pallets-eco/blinker/) because it has reputable authors, reasonable buy-in from the community, and is maintained. We need some sort of signalling in general because we need to turn custom allocation on and off depending on the project selected (see https://github.com/brightway-lca/multifunctional/pull/21).