### PR TITLE
Set node types when writing a `Database`

### DIFF
--- a/bw2data/backends/base.py
+++ b/bw2data/backends/base.py
@@ -362,14 +362,16 @@ class SQLiteBackend(ProcessedDataStore):
 
         def relabel_exchanges(obj: dict, old_name: str, new_name: str) -> dict:
             for e in obj.get("exchanges", []):
-                if "input" in e and e['input'][0] == old_name:
+                if "input" in e and e["input"][0] == old_name:
                     e["input"] = (new_name, e["input"][1])
-                if "output" in e and e['output'][0] == old_name:
+                if "output" in e and e["output"][0] == old_name:
                     e["output"] = (new_name, e["output"][1])
 
             return obj
 
-        return dict([((new_name, k[1]), relabel_exchanges(v, old_name, new_name)) for k, v in data.items()])
+        return dict(
+            [((new_name, k[1]), relabel_exchanges(v, old_name, new_name)) for k, v in data.items()]
+        )
 
     def rename(self, name):
         """Rename a database. Modifies exchanges to link to new name. Deregisters old database.
@@ -518,7 +520,7 @@ class SQLiteBackend(ProcessedDataStore):
                 check_exchange_keys(exchange)
 
             if "output" not in exchange:
-                exchange["output"] = (ds['database'], ds['code'])
+                exchange["output"] = (ds["database"], ds["code"])
             exchanges.append(dict_as_exchangedataset(exchange))
 
             # Query gets passed as INSERT INTO x VALUES ('?', '?'...)
@@ -593,6 +595,7 @@ class SQLiteBackend(ProcessedDataStore):
             }
 
         Writing a database will first deletes all existing data."""
+
         def merger(d1: dict, d2: dict) -> dict:
             """The joys of 3.9 compatibility"""
             d1.update(d2)
@@ -605,7 +608,7 @@ class SQLiteBackend(ProcessedDataStore):
 
         if self.name not in databases:
             self.register(write_empty=False)
-        wrong_database = {ds['database'] for ds in data}.difference({self.name})
+        wrong_database = {ds["database"] for ds in data}.difference({self.name})
         if wrong_database:
             raise WrongDatabase(
                 "Can't write activities in databases {} to database {}".format(

--- a/bw2data/backends/base.py
+++ b/bw2data/backends/base.py
@@ -43,7 +43,7 @@ from bw2data.errors import (
 )
 from bw2data.query import Query
 from bw2data.search import IndexManager, Searcher
-from bw2data.utils import as_uncertainty_dict, get_geocollection, get_node
+from bw2data.utils import as_uncertainty_dict, get_geocollection, get_node, set_correct_process_type
 
 _VALID_KEYS = {"location", "name", "product", "type"}
 
@@ -601,10 +601,10 @@ class SQLiteBackend(ProcessedDataStore):
             d1.update(d2)
             return d1
 
-        print("In write:", data)
-
         if isinstance(data, dict):
             data = [merger(v, {"database": db, "code": code}) for (db, code), v in data.items()]
+
+        data = [set_correct_process_type(dataset) for dataset in data]
 
         if self.name not in databases:
             self.register(write_empty=False)

--- a/bw2data/backends/base.py
+++ b/bw2data/backends/base.py
@@ -262,7 +262,7 @@ class SQLiteBackend(ProcessedDataStore):
             for ds in data.values()
             for exc in ds.get("exchanges", [])
             if ds.get("type") in labels.process_node_types
-            and exc.get("type") != "unknown"
+            and exc.get("type") in labels.lci_edge_types
             and exc.get("input", [None])[0] is not None
             and exc.get("input", [None])[0] not in ignore
         }

--- a/bw2data/backends/base.py
+++ b/bw2data/backends/base.py
@@ -7,7 +7,7 @@ import uuid
 import warnings
 from collections import defaultdict
 from functools import partial
-from typing import Callable, Iterable, List, Optional
+from typing import Callable, Iterable, List, Optional, Union
 
 import pandas
 from bw_processing import Datapackage, clean_datapackage_name, create_datapackage
@@ -223,12 +223,12 @@ class SQLiteBackend(ProcessedDataStore):
 
         """
         assert name not in databases, ValueError("This database exists")
-        data = self.relabel_data(copy.deepcopy(self.load()), name)
+        data = self.relabel_data(copy.deepcopy(self.load()), self.name, name)
         with warnings.catch_warnings():
             warnings.simplefilter("ignore")
             new_database = self.__class__(name)
             new_database.register(
-                format="Brightway2 copy",
+                format=f"Copied from '{self.name}'",
             )
 
         new_database.write(data, searchable=databases[name].get("searchable"))
@@ -308,7 +308,7 @@ class SQLiteBackend(ProcessedDataStore):
         if write_empty:
             self.write({}, searchable=False)
 
-    def relabel_data(self, data, new_name):
+    def relabel_data(self, data: dict, old_name: str, new_name: str) -> dict:
         """Relabel database keys and exchanges.
 
         In a database which internally refer to the same database, update to new database name ``new_name``.
@@ -360,13 +360,16 @@ class SQLiteBackend(ProcessedDataStore):
 
         """
 
-        def relabel_exchanges(obj, new_name):
+        def relabel_exchanges(obj: dict, old_name: str, new_name: str) -> dict:
             for e in obj.get("exchanges", []):
-                if e["input"] in data:
+                if "input" in e and e['input'][0] == old_name:
                     e["input"] = (new_name, e["input"][1])
+                if "output" in e and e['output'][0] == old_name:
+                    e["output"] = (new_name, e["output"][1])
+
             return obj
 
-        return dict([((new_name, k[1]), relabel_exchanges(v, new_name)) for k, v in data.items()])
+        return dict([((new_name, k[1]), relabel_exchanges(v, old_name, new_name)) for k, v in data.items()])
 
     def rename(self, name):
         """Rename a database. Modifies exchanges to link to new name. Deregisters old database.
@@ -383,7 +386,7 @@ class SQLiteBackend(ProcessedDataStore):
             warnings.simplefilter("ignore")
             new_db = self.__class__(name)
             databases[name] = databases[old_name]
-        new_data = self.relabel_data(self.load(), name)
+        new_data = self.relabel_data(self.load(), old_name, name)
         new_db.write(new_data, searchable=databases[name].get("searchable"))
         del databases[old_name]
         self.name = name
@@ -499,7 +502,6 @@ class SQLiteBackend(ProcessedDataStore):
 
     def _efficient_write_dataset(
         self,
-        key: tuple,
         ds: dict,
         exchanges: list,
         activities: list,
@@ -515,7 +517,8 @@ class SQLiteBackend(ProcessedDataStore):
                 check_exchange_type(exchange.get("type"))
                 check_exchange_keys(exchange)
 
-            exchange["output"] = key
+            if "output" not in exchange:
+                exchange["output"] = (ds['database'], ds['code'])
             exchanges.append(dict_as_exchangedataset(exchange))
 
             # Query gets passed as INSERT INTO x VALUES ('?', '?'...)
@@ -528,8 +531,6 @@ class SQLiteBackend(ProcessedDataStore):
                 exchanges = []
 
         ds = {k: v for k, v in ds.items() if k != "exchanges"}
-        ds["database"] = key[0]
-        ds["code"] = key[1]
 
         if check_typos:
             check_activity_type(ds.get("type"))
@@ -544,7 +545,7 @@ class SQLiteBackend(ProcessedDataStore):
         return exchanges, activities
 
     def _efficient_write_many_data(
-        self, data: dict, indices: bool = True, check_typos: bool = True
+        self, data: list, indices: bool = True, check_typos: bool = True
     ) -> None:
         be_complicated = len(data) >= 100 and indices
         if be_complicated:
@@ -555,9 +556,9 @@ class SQLiteBackend(ProcessedDataStore):
             self.delete(keep_params=True, warn=False, vacuum=False)
             exchanges, activities = [], []
 
-            for key, ds in tqdm_wrapper(data.items(), getattr(config, "is_test", False)):
+            for ds in tqdm_wrapper(data, getattr(config, "is_test", False)):
                 exchanges, activities = self._efficient_write_dataset(
-                    key, ds, exchanges, activities, check_typos
+                    ds, exchanges, activities, check_typos
                 )
 
             if activities:
@@ -578,7 +579,7 @@ class SQLiteBackend(ProcessedDataStore):
 
     def write(
         self,
-        data: dict,
+        data: Union[dict, list],
         process: bool = True,
         searchable: bool = True,
         check_typos: bool = True,
@@ -592,9 +593,19 @@ class SQLiteBackend(ProcessedDataStore):
             }
 
         Writing a database will first deletes all existing data."""
+        def merger(d1: dict, d2: dict) -> dict:
+            """The joys of 3.9 compatibility"""
+            d1.update(d2)
+            return d1
+
+        print("In write:", data)
+
+        if isinstance(data, dict):
+            data = [merger(v, {"database": db, "code": code}) for (db, code), v in data.items()]
+
         if self.name not in databases:
             self.register(write_empty=False)
-        wrong_database = {key[0] for key in data}.difference({self.name})
+        wrong_database = {ds['database'] for ds in data}.difference({self.name})
         if wrong_database:
             raise WrongDatabase(
                 "Can't write activities in databases {} to database {}".format(
@@ -606,9 +617,9 @@ class SQLiteBackend(ProcessedDataStore):
 
         databases.set_modified(self.name)
         geocollections = {
-            get_geocollection(x.get("location"))
-            for x in data.values()
-            if x.get("type") in labels.process_node_types
+            get_geocollection(dataset.get("location"))
+            for dataset in data
+            if dataset.get("type") in labels.process_node_types
         }
         if None in geocollections:
             print(
@@ -618,7 +629,7 @@ class SQLiteBackend(ProcessedDataStore):
         databases[self.name]["geocollections"] = sorted(geocollections)
         # processing will flush the database metadata
 
-        geomapping.add({x["location"] for x in data.values() if x.get("location")})
+        geomapping.add({x["location"] for x in data if x.get("location")})
         if data:
             try:
                 self._efficient_write_many_data(data, check_typos=check_typos)
@@ -674,7 +685,7 @@ class SQLiteBackend(ProcessedDataStore):
         else:
             obj["code"] = str(code)
 
-        if kwargs.get("type") in labels.edge_types:
+        if kwargs.get("type") in labels.lci_edge_types:
             EDGE_LABELS = """
 Edge type label used for node.
 You gave the type "{}". This is normally used for *edges*, not for *nodes*.

--- a/bw2data/backends/base.py
+++ b/bw2data/backends/base.py
@@ -842,8 +842,8 @@ Here are the type values usually used for nodes:
         # Try to avoid race conditions - but no guarantee
         self.metadata["processed"] = datetime.datetime.now().isoformat()
         # Get number of exchanges and processes to set
-        # initial Numpy array size (still have to include)
-        # implicit production exchanges
+        # initial Numpy array size (still have to include
+        # implicit production exchanges)
         dependents = set()
 
         # self.filepath_processed checks if data is dirty,
@@ -874,7 +874,7 @@ Here are the type values usually used for nodes:
                 # Get correct database name
                 ActivityDataset.database == self.name,
                 # Only consider `process` type activities
-                ActivityDataset.type << labels.process_node_types,
+                ActivityDataset.type << labels.implicit_production_allowed_node_types,
                 # But exclude activities that already have production exchanges
                 ~(
                     ActivityDataset.code

--- a/bw2data/compat.py
+++ b/bw2data/compat.py
@@ -1,6 +1,7 @@
 from typing import Dict, List, Union
 
 from bw_processing.datapackage import DatapackageBase
+from deprecated import deprecated
 
 from bw2data import (
     Database,
@@ -26,15 +27,15 @@ class Mapping:
     Used only for backwards compatibility; preferred method is now to look up the ids of activities directly in the SQlite database.
     """
 
+    @deprecated("This method is no longer necessary, and does nothing.")
     def add(self, keys):
-        raise DeprecationWarning("This method is no longer necessary, and does nothing.")
         return
 
     def __getitem__(self, key):
         return get_id(key)
 
+    @deprecated("This method is no longer necessary, and does nothing.")
     def delete(self, keys):
-        raise DeprecationWarning("This method is no longer necessary, and does nothing.")
         return
 
     def __str__(self):

--- a/bw2data/compat.py
+++ b/bw2data/compat.py
@@ -14,8 +14,9 @@ from bw2data import (
     projects,
     weightings,
 )
-from bw2data.backends.schema import get_id, ActivityDataset as AD
 from bw2data.backends import Node
+from bw2data.backends.schema import ActivityDataset as AD
+from bw2data.backends.schema import get_id
 from bw2data.errors import Brightway2Project, UnknownObject
 
 
@@ -52,7 +53,7 @@ def unpack(dct) -> str:
         elif isinstance(obj, tuple):
             yield obj[0]
         elif isinstance(obj, int):
-            yield get_node(id=obj)['database']
+            yield get_node(id=obj)["database"]
         else:
             raise ValueError
 

--- a/bw2data/configuration.py
+++ b/bw2data/configuration.py
@@ -7,12 +7,13 @@ from pydantic_settings import BaseSettings, SettingsConfigDict
 
 
 class MatrixLabels(BaseSettings):
-    node_types: List[str] = [
+    lci_node_types: List[str] = [
         "process",
         "product",
         "processwithreferenceproduct",
         "multifunctional",
     ]
+    other_node_types: List[str] = []
     process_node_types: List[str] = ["process", "processwithreferenceproduct"]
     product_node_types: List[str] = ["product"]
 
@@ -34,6 +35,7 @@ class MatrixLabels(BaseSettings):
     ]
     # You should normally use `technosphere_positive_edge_types`, as it includes substitution
     substitution_edge_types: List[str] = ["substitution"]
+    other_edge_types: List[str] = []
 
     production_edge_default: str = "production"
     consumption_edge_default: str = "technosphere"
@@ -41,7 +43,7 @@ class MatrixLabels(BaseSettings):
     substitution_edge_default: str = "substitution"
 
     @property
-    def lci_edge_types(self):
+    def lci_edge_types(self) -> List[str]:
         return sorted(
             set(
                 self.biosphere_edge_types
@@ -52,9 +54,12 @@ class MatrixLabels(BaseSettings):
         )
 
     @property
-    @deprecated("Use `lci_edge_types` instead; there are other edge types. Will be removed in v5")
-    def edge_types(self):
-        return self.lci_edge_types
+    def edge_types(self) -> List[str]:
+        return sorted(set(self.lci_edge_types + self.other_edge_types))
+
+    @property
+    def node_types(self) -> List[str]:
+        return sorted(set(self.lci_node_types + self.other_node_types))
 
     model_config = SettingsConfigDict(
         env_file="brightway-matrix-configuration.env",

--- a/bw2data/configuration.py
+++ b/bw2data/configuration.py
@@ -2,6 +2,7 @@ import platform
 from pathlib import Path
 from typing import List, Union
 
+from deprecated import deprecated
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 
@@ -41,7 +42,7 @@ class MatrixLabels(BaseSettings):
     substitution_edge_default: str = "substitution"
 
     @property
-    def edge_types(self):
+    def lci_edge_types(self):
         return sorted(
             set(
                 self.biosphere_edge_types
@@ -50,6 +51,11 @@ class MatrixLabels(BaseSettings):
                 + self.substitution_edge_types
             )
         )
+
+    @property
+    @deprecated("Use `lci_edge_types` instead; there are other edge types. Will be removed in v5")
+    def edge_types(self):
+        return self.lci_edge_types
 
     model_config = SettingsConfigDict(
         env_file="brightway-matrix-configuration.env",

--- a/bw2data/configuration.py
+++ b/bw2data/configuration.py
@@ -43,6 +43,10 @@ class MatrixLabels(BaseSettings):
     substitution_edge_default: str = "substitution"
 
     @property
+    def implicit_production_allowed_node_types(self):
+        return [self.chimaera_node_default]
+
+    @property
     def lci_edge_types(self) -> List[str]:
         return sorted(
             set(

--- a/bw2data/configuration.py
+++ b/bw2data/configuration.py
@@ -1,20 +1,19 @@
 import platform
 from pathlib import Path
-from typing import List, Union
+from typing import List
 
 from deprecated import deprecated
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 
 class MatrixLabels(BaseSettings):
-    node_types: List[Union[str, None]] = [
+    node_types: List[str] = [
         "process",
         "product",
         "processwithreferenceproduct",
         "multifunctional",
-        None,
     ]
-    process_node_types: List[Union[str, None]] = ["process", "processwithreferenceproduct", None]
+    process_node_types: List[str] = ["process", "processwithreferenceproduct"]
     product_node_types: List[str] = ["product"]
 
     process_node_default: str = "process"

--- a/bw2data/utils.py
+++ b/bw2data/utils.py
@@ -13,6 +13,7 @@ from pathlib import Path
 from typing import List
 
 import stats_arrays as sa
+from deprecated import deprecated
 
 from bw2data.configuration import labels
 from bw2data.errors import MultipleResults, NotFound, UnknownObject, ValidityError
@@ -21,8 +22,11 @@ from bw2data.fatomic import open
 DOWNLOAD_URL = "https://brightway.dev/data/"
 
 
+@deprecated("`safe_filename` has been moved to `bw_processing`; will be removed in v5")
 def safe_filename(*args, **kwargs):
-    raise DeprecationWarning("`safe_filename` has been moved to `bw_processing`")
+    from bw_processing import safe_filename
+
+    return safe_filename(*args, **kwargs)
 
 
 def maybe_path(x):
@@ -308,18 +312,11 @@ def set_data_dir(dirpath, permanent=True):
     Creates ``dirpath`` if needed. Also creates basic directories, and resets metadata.
 
     """
-    warnings.warn(
-        "`set_data_dir` is deprecated; use `projects.set_current('my "
-        "project name')` for a new project space.",
-        DeprecationWarning,
-    )
+    raise NotImplementedError("Change projects using `projects.set_current()`")
 
 
 def switch_data_directory(dirpath):
-    warnings.warn(
-        "`switch_data_directory` is deprecated; use `projects.change_base_directories`.",
-        DeprecationWarning,
-    )
+    raise NotImplementedError("Change projects using `projects.set_current()`")
 
 
 def create_in_memory_zipfile_from_directory(path):

--- a/bw2data/utils.py
+++ b/bw2data/utils.py
@@ -421,11 +421,11 @@ def get_geocollection(location, default_global_location=False):
 
 def set_correct_process_type(dataset: dict) -> dict:
     """
-Change the `type` for an LCI process under certain conditions.
+    Change the `type` for an LCI process under certain conditions.
 
-Only will make changes if the following conditions are met:
+    Only will make changes if the following conditions are met:
 
-* `type` is `None` or missing -> set to either `process` or `processwithreferenceproduct`
-* `type` is `process` but the dataset also includes a reference product -> `processwithreferenceproduct`
+    * `type` is `None` or missing -> set to either `process` or `processwithreferenceproduct`
+    * `type` is `process` but the dataset also includes a reference product -> `processwithreferenceproduct`
 
     """

--- a/bw2data/utils.py
+++ b/bw2data/utils.py
@@ -417,3 +417,15 @@ def get_geocollection(location, default_global_location=False):
         return "world"
     else:
         return None
+
+
+def set_correct_process_type(dataset: dict) -> dict:
+    """
+Change the `type` for an LCI process under certain conditions.
+
+Only will make changes if the following conditions are met:
+
+* `type` is `None` or missing -> set to either `process` or `processwithreferenceproduct`
+* `type` is `process` but the dataset also includes a reference product -> `processwithreferenceproduct`
+
+    """

--- a/bw2data/utils.py
+++ b/bw2data/utils.py
@@ -430,16 +430,11 @@ def set_correct_process_type(dataset: dict) -> dict:
     """
     this = (dataset["database"], dataset["code"])
     if dataset.get("type") not in (labels.process_node_default, None):
-        print("Condition 1")
         pass
     elif any(exc.get("input") == this for exc in dataset.get("exchanges", [])):
         # Explicit self production/consumption -> chimaera
-        print("Condition 2")
         dataset["type"] = labels.chimaera_node_default
-    elif (
-        any(exc.get("functional") for exc in dataset.get("exchanges", []))
-    ):
-        print("Condition 3")
+    elif any(exc.get("functional") for exc in dataset.get("exchanges", [])):
         dataset["type"] = labels.process_node_default
     elif (
         # No production edges -> implicit self production -> chimaera
@@ -448,14 +443,11 @@ def set_correct_process_type(dataset: dict) -> dict:
             for exc in dataset.get("exchanges", [])
         )
     ):
-        print("Condition 4")
         dataset["type"] = labels.chimaera_node_default
     elif not dataset.get("type"):
-        print("Condition 5")
         dataset["type"] = labels.process_node_default
     else:
         # No conditions for setting or changing type occurred
-        print("Condition 6")
         pass
 
     return dataset

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,6 +32,7 @@ dependencies = [
     "blinker",
     "bw2parameters",
     "bw_processing>=0.9.5",
+    "deprecated",
     "fsspec",
     "lxml",
     "numpy<2",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -118,3 +118,4 @@ include_trailing_comma = true
 force_grid_wrap = 0
 use_parentheses = true
 ensure_newline_before_comments = true
+skip = ["bw2data/__init__.py", "bw2data/backends/__init__.py"]

--- a/tests/compatibility.py
+++ b/tests/compatibility.py
@@ -9,8 +9,8 @@ from bw2data import (
     databases,
     geomapping,
     get_activity,
-    get_node,
     get_multilca_data_objs,
+    get_node,
     methods,
     normalizations,
     prepare_lca_inputs,
@@ -102,9 +102,7 @@ def test_prepare_lca_inputs_only_method(setup):
 def test_prepare_lca_inputs_multiple_demands_data_types(setup):
     first = get_node(database="food", code="1")
     second = get_node(database="food", code="2")
-    d, objs, r = prepare_lca_inputs(
-        demands=[{first: 1}, {second.id: 10}], method=("foo",)
-    )
+    d, objs, r = prepare_lca_inputs(demands=[{first: 1}, {second.id: 10}], method=("foo",))
     assert d == [{3: 1}, {4: 10}]
     assert {o.metadata["id"] for o in objs} == {o.datapackage().metadata["id"] for o in setup}
 

--- a/tests/database.py
+++ b/tests/database.py
@@ -734,7 +734,7 @@ def test_can_split_processes_products():
                 "exchanges": [
                     {
                         "input": ("a database", "product"),
-                        "output": ("a database", "product"),
+                        "output": ("a database", "foo"),
                         "type": "production",
                         "amount": 1,
                     }

--- a/tests/database.py
+++ b/tests/database.py
@@ -565,6 +565,7 @@ def test_find_dependents():
                     },
                 ],
                 "location": "bar",
+                "type": "process",
             },
             ("a database", "baz"): {
                 "exchanges": [

--- a/tests/database.py
+++ b/tests/database.py
@@ -148,16 +148,24 @@ def test_delete_warning():
 def test_relabel_data():
     old_data = {
         ("old and boring", "1"): {
-            "exchanges": [{"input": ("old and boring", "42"), "amount": 1.0}]
+            "exchanges": [
+                {"input": ("old and boring", "42"), "output": ("old and boring", "1"), "amount": 1.0},
+                {"input": ("something else", "42"), "output": ("old and boring", "1"), "amount": 1.0},
+                {"input": ("old and boring", "42"), "output": ("something else", "123"), "amount": 1.0},
+            ]
         },
         ("old and boring", "2"): {"exchanges": [{"input": ("old and boring", "1"), "amount": 4.0}]},
     }
     shiny_new = {
-        ("shiny new", "1"): {"exchanges": [{"input": ("old and boring", "42"), "amount": 1.0}]},
+        ("shiny new", "1"): {"exchanges": [
+                {"input": ("shiny new", "42"), "output": ("shiny new", "1"), "amount": 1.0},
+                {"input": ("something else", "42"), "output": ("shiny new", "1"), "amount": 1.0},
+                {"input": ("shiny new", "42"), "output": ("something else", "123"), "amount": 1.0},
+        ]},
         ("shiny new", "2"): {"exchanges": [{"input": ("shiny new", "1"), "amount": 4.0}]},
     }
     db = Database("foo")
-    assert shiny_new == db.relabel_data(old_data, "shiny new")
+    assert shiny_new == db.relabel_data(old_data, "old and boring", "shiny new")
 
 
 ### Metadata
@@ -919,14 +927,28 @@ def test_delete_duplicate_exchanges():
 
 
 @bw2test
-def test_add_geocollections(capsys):
+def test_add_geocollections_dict(capsys):
     db = Database("test-case")
     db.write(
         {
-            ("test-case", "1"): {"location": "RU", "exchanges": []},
-            ("test-case", "2"): {"exchanges": []},
-            ("test-case", "3"): {"exchanges": [], "location": ("foo", "bar")},
+            ("test-case", "1"): {"location": "RU", "exchanges": [], "type": "process"},
+            ("test-case", "2"): {"exchanges": [], "type": "processwithreferenceproduct"},
+            ("test-case", "3"): {"exchanges": [], "location": ("foo", "bar"), "type": "processwithreferenceproduct"},
         }
+    )
+    assert db.metadata["geocollections"] == ["foo", "world"]
+    assert "Not able" in capsys.readouterr().out
+
+
+@bw2test
+def test_add_geocollections_list(capsys):
+    db = Database("test-case")
+    db.write(
+        [
+            {"database": "test-case", "code": "1", "location": "RU", "exchanges": [], "type": "process"},
+            {"database": "test-case", "code": "2", "exchanges": [], "type": "processwithreferenceproduct"},
+            {"database": "test-case", "code": "3", "exchanges": [], "location": ("foo", "bar"), "type": "processwithreferenceproduct"},
+        ]
     )
     assert db.metadata["geocollections"] == ["foo", "world"]
     assert "Not able" in capsys.readouterr().out
@@ -937,12 +959,13 @@ def test_set_geocollections(capsys):
     db = Database("test-case")
     db.write(
         {
-            ("test-case", "1"): {"location": "RU", "exchanges": [], "name": "a"},
-            ("test-case", "2"): {"exchanges": [], "name": "b"},
+            ("test-case", "1"): {"location": "RU", "exchanges": [], "name": "a", "type": "processwithreferenceproduct"},
+            ("test-case", "2"): {"exchanges": [], "name": "b", "type": "process"},
             ("test-case", "3"): {
                 "exchanges": [],
                 "location": ("foo", "bar"),
                 "name": "c",
+                "type": "processwithreferenceproduct"
             },
         }
     )
@@ -966,8 +989,8 @@ def test_add_geocollections_unable(capsys):
     db = Database("test-case")
     db.write(
         {
-            ("test-case", "1"): {"location": "Russia", "exchanges": []},
-            ("test-case", "3"): {"exchanges": [], "location": ("foo", "bar")},
+            ("test-case", "1"): {"location": "Russia", "exchanges": [], "type": "process"},
+            ("test-case", "3"): {"exchanges": [], "location": ("foo", "bar"), "type": "process"},
         }
     )
     assert db.metadata["geocollections"] == ["foo"]
@@ -984,7 +1007,7 @@ def test_add_geocollections_no_unable_for_product(capsys):
                 "type": "product",
                 "exchanges": [],
             },
-            ("test-case", "3"): {"exchanges": [], "location": ("foo", "bar")},
+            ("test-case", "3"): {"exchanges": [], "location": ("foo", "bar"), "type": "process"},
         }
     )
     assert db.metadata["geocollections"] == ["foo"]

--- a/tests/database.py
+++ b/tests/database.py
@@ -149,19 +149,33 @@ def test_relabel_data():
     old_data = {
         ("old and boring", "1"): {
             "exchanges": [
-                {"input": ("old and boring", "42"), "output": ("old and boring", "1"), "amount": 1.0},
-                {"input": ("something else", "42"), "output": ("old and boring", "1"), "amount": 1.0},
-                {"input": ("old and boring", "42"), "output": ("something else", "123"), "amount": 1.0},
+                {
+                    "input": ("old and boring", "42"),
+                    "output": ("old and boring", "1"),
+                    "amount": 1.0,
+                },
+                {
+                    "input": ("something else", "42"),
+                    "output": ("old and boring", "1"),
+                    "amount": 1.0,
+                },
+                {
+                    "input": ("old and boring", "42"),
+                    "output": ("something else", "123"),
+                    "amount": 1.0,
+                },
             ]
         },
         ("old and boring", "2"): {"exchanges": [{"input": ("old and boring", "1"), "amount": 4.0}]},
     }
     shiny_new = {
-        ("shiny new", "1"): {"exchanges": [
+        ("shiny new", "1"): {
+            "exchanges": [
                 {"input": ("shiny new", "42"), "output": ("shiny new", "1"), "amount": 1.0},
                 {"input": ("something else", "42"), "output": ("shiny new", "1"), "amount": 1.0},
                 {"input": ("shiny new", "42"), "output": ("something else", "123"), "amount": 1.0},
-        ]},
+            ]
+        },
         ("shiny new", "2"): {"exchanges": [{"input": ("shiny new", "1"), "amount": 4.0}]},
     }
     db = Database("foo")
@@ -933,7 +947,11 @@ def test_add_geocollections_dict(capsys):
         {
             ("test-case", "1"): {"location": "RU", "exchanges": [], "type": "process"},
             ("test-case", "2"): {"exchanges": [], "type": "processwithreferenceproduct"},
-            ("test-case", "3"): {"exchanges": [], "location": ("foo", "bar"), "type": "processwithreferenceproduct"},
+            ("test-case", "3"): {
+                "exchanges": [],
+                "location": ("foo", "bar"),
+                "type": "processwithreferenceproduct",
+            },
         }
     )
     assert db.metadata["geocollections"] == ["foo", "world"]
@@ -945,9 +963,26 @@ def test_add_geocollections_list(capsys):
     db = Database("test-case")
     db.write(
         [
-            {"database": "test-case", "code": "1", "location": "RU", "exchanges": [], "type": "process"},
-            {"database": "test-case", "code": "2", "exchanges": [], "type": "processwithreferenceproduct"},
-            {"database": "test-case", "code": "3", "exchanges": [], "location": ("foo", "bar"), "type": "processwithreferenceproduct"},
+            {
+                "database": "test-case",
+                "code": "1",
+                "location": "RU",
+                "exchanges": [],
+                "type": "process",
+            },
+            {
+                "database": "test-case",
+                "code": "2",
+                "exchanges": [],
+                "type": "processwithreferenceproduct",
+            },
+            {
+                "database": "test-case",
+                "code": "3",
+                "exchanges": [],
+                "location": ("foo", "bar"),
+                "type": "processwithreferenceproduct",
+            },
         ]
     )
     assert db.metadata["geocollections"] == ["foo", "world"]
@@ -959,13 +994,18 @@ def test_set_geocollections(capsys):
     db = Database("test-case")
     db.write(
         {
-            ("test-case", "1"): {"location": "RU", "exchanges": [], "name": "a", "type": "processwithreferenceproduct"},
+            ("test-case", "1"): {
+                "location": "RU",
+                "exchanges": [],
+                "name": "a",
+                "type": "processwithreferenceproduct",
+            },
             ("test-case", "2"): {"exchanges": [], "name": "b", "type": "process"},
             ("test-case", "3"): {
                 "exchanges": [],
                 "location": ("foo", "bar"),
                 "name": "c",
-                "type": "processwithreferenceproduct"
+                "type": "processwithreferenceproduct",
             },
         }
     )

--- a/tests/database.py
+++ b/tests/database.py
@@ -1181,7 +1181,7 @@ def test_nodes_to_dataframe_simple(df_fixture):
                 "id": get_id(("food", "2")),
                 "location": "CH",
                 "name": "dinner",
-                "type": "process",
+                "type": "processwithreferenceproduct",
                 "unit": "kg",
             },
             {
@@ -1191,7 +1191,7 @@ def test_nodes_to_dataframe_simple(df_fixture):
                 "id": get_id(("food", "1")),
                 "location": "CA",
                 "name": "lunch",
-                "type": "process",
+                "type": "processwithreferenceproduct",
                 "unit": "kg",
             },
         ]

--- a/tests/iotable.py
+++ b/tests/iotable.py
@@ -51,9 +51,24 @@ def iotable_fixture():
 
     cat = Database("cat", backend="iotable")
     cat_data = {
-        ("cat", "a"): {"name": "a", "unit": "meow", "location": "sunshine"},
-        ("cat", "b"): {"name": "b", "unit": "purr", "location": "curled up"},
-        ("cat", "c"): {"name": "c", "unit": "meow", "location": "on lap"},
+        ("cat", "a"): {
+            "name": "a",
+            "unit": "meow",
+            "location": "sunshine",
+            "type": "processwithreferenceproduct",
+        },
+        ("cat", "b"): {
+            "name": "b",
+            "unit": "purr",
+            "location": "curled up",
+            "type": "processwithreferenceproduct",
+        },
+        ("cat", "c"): {
+            "name": "c",
+            "unit": "meow",
+            "location": "on lap",
+            "type": "processwithreferenceproduct",
+        },
     }
     cat.write(cat_data)
     cat.write_exchanges(
@@ -261,6 +276,7 @@ def test_iotable_nodes_to_dataframe(iotable_fixture):
                 "id": get_id(("cat", "a")),
                 "location": "sunshine",
                 "name": "a",
+                "type": "processwithreferenceproduct",
                 "unit": "meow",
             },
             {
@@ -269,6 +285,7 @@ def test_iotable_nodes_to_dataframe(iotable_fixture):
                 "id": get_id(("cat", "b")),
                 "location": "curled up",
                 "name": "b",
+                "type": "processwithreferenceproduct",
                 "unit": "purr",
             },
             {
@@ -277,10 +294,13 @@ def test_iotable_nodes_to_dataframe(iotable_fixture):
                 "id": get_id(("cat", "c")),
                 "location": "on lap",
                 "name": "c",
+                "type": "processwithreferenceproduct",
                 "unit": "meow",
             },
         ]
     )
+    print(df.reset_index(drop=True))
+    print(expected.reset_index(drop=True))
     assert_frame_equal(
         df.reset_index(drop=True),
         expected.reset_index(drop=True),


### PR DESCRIPTION
This PR adds a utility function `set_correct_process_type` and applies it when writing `Database` data. This means that every node written to the datastore will have a `type` attribute (before this could be missing or `None`). We also differentiate `process` and `processwithreferenceproduct` nodes, and fix nodes with the type `process` which should be `processwithreferenceproduct`.

This PR allows for GUIs to cleanly differentiate LCI node types in their data tables. Only nodes with types `product` and `processwithreferenceproduct` can be used as functional units (but please don't hard-code these values, use `bw2data.labels.product_node_types` and `bw2data.labels.chimaera_node_default`).

A `processwithreferenceproduct` node is one which consumes or produces its own product - i.e. this node exists as both a row and column in the technosphere matrix. Contrast this with `process`, which is only a column in the matrix, and consumes and produces `products`, which are rows.

Eventually we should phase out `processwithreferenceproduct` as this makes the code more complicated and prone to errors. It is much cleaner and simpler to have explicit `process` and `product` nodes.

This is a big change and could break some code:

* It changes data when calling `.write()` as it guarantees that `type` is always present
* Many datasets will have their type label changed from `process` to `processwithreferenceproduct` (e.g. all ecoinvent). Code with uses hard-coded "process" values will break. See `bw2data.configuration` for more details on labels you should expect.
* Only nodes with type `processwithreferenceproduct` will be checked for implicit production. This shouldn't break anything as we change `process` to `processwithreferenceproduct` if implicit production was going to be added.