### PR TITLE
Replace `print` with logging and add optional `structlog`

### DIFF
--- a/bw2data/backends/iotable/backend.py
+++ b/bw2data/backends/iotable/backend.py
@@ -10,6 +10,7 @@ from bw2data import config, databases, geomapping
 from bw2data.backends import SQLiteBackend
 from bw2data.backends.iotable.proxies import IOTableActivity, IOTableExchanges
 from bw2data.configuration import labels
+from bw2data.logs import stdout_feedback_logger
 
 
 class IOTableBackend(SQLiteBackend):
@@ -34,7 +35,7 @@ class IOTableBackend(SQLiteBackend):
         Technosphere and biosphere data has format ``(row id, col id, value, flip)``.
 
         """
-        print("Starting IO table write")
+        stdout_feedback_logger.info("Starting IO table write")
 
         # create empty datapackage
         dp = create_datapackage(
@@ -59,7 +60,7 @@ class IOTableBackend(SQLiteBackend):
             nrows=len(self),
         )
 
-        print("Adding technosphere matrix")
+        stdout_feedback_logger.info("Adding technosphere matrix")
         # if technosphere is a dictionary pass it's keys & values
         if isinstance(technosphere, dict):
             dp.add_persistent_vector(
@@ -77,7 +78,7 @@ class IOTableBackend(SQLiteBackend):
         else:
             raise Exception(f"Error: Unsupported technosphere type: {type(technosphere)}")
 
-        print("Adding biosphere matrix")
+        stdout_feedback_logger.info("Adding biosphere matrix")
         # if biosphere is a dictionary pass it's keys & values
         if isinstance(biosphere, dict):
             dp.add_persistent_vector(
@@ -96,7 +97,7 @@ class IOTableBackend(SQLiteBackend):
             raise Exception(f"Error: Unsupported biosphere type: {type(technosphere)}")
 
         # finalize
-        print("Finalizing serialization")
+        stdout_feedback_logger.info("Finalizing serialization")
         dp.finalize_serialization()
 
         databases[self.name]["depends"] = sorted(set(dependents).difference({self.name}))
@@ -142,7 +143,7 @@ class IOTableBackend(SQLiteBackend):
         def cached_lookup(id_):
             return get_node(id=id_)
 
-        print("Retrieving metadata")
+        stdout_feedback_logger.info("Retrieving metadata")
         activities = {o.id: o for o in self}
 
         def get(id_):
@@ -189,7 +190,7 @@ class IOTableBackend(SQLiteBackend):
 
             return np.hstack(arrays)
 
-        print("Loading datapackage")
+        stdout_feedback_logger.info("Loading datapackage")
         exchanges = IOTableExchanges(datapackage=self.datapackage())
 
         target_ids = np.hstack(
@@ -201,11 +202,11 @@ class IOTableBackend(SQLiteBackend):
         edge_amounts = np.hstack([resource["data"]["array"] for resource in exchanges.resources])
         edge_types = get_edge_types(exchanges)
 
-        print("Creating metadata dataframes")
+        stdout_feedback_logger.info("Creating metadata dataframes")
         target_metadata = metadata_dataframe(target_ids)
         source_metadata = metadata_dataframe(source_ids, "source_")
 
-        print("Building merged dataframe")
+        stdout_feedback_logger.info("Building merged dataframe")
         df = pd.DataFrame(
             {
                 "target_id": target_ids,
@@ -233,7 +234,7 @@ class IOTableBackend(SQLiteBackend):
             "source_categories",
             "edge_type",
         ]
-        print("Compressing DataFrame")
+        stdout_feedback_logger.info("Compressing DataFrame")
         for column in categorical_columns:
             if column in df.columns:
                 df[column] = df[column].astype("category")

--- a/bw2data/backends/proxies.py
+++ b/bw2data/backends/proxies.py
@@ -19,6 +19,7 @@ from bw2data.configuration import labels
 from bw2data.errors import ValidityError
 from bw2data.proxies import ActivityProxyBase, ExchangeProxyBase
 from bw2data.search import IndexManager
+from bw2data.logs import stdout_feedback_logger
 
 
 class Exchanges(Iterable):
@@ -238,10 +239,10 @@ class Activity(ActivityProxyBase):
             raise ValueError("`id` is read-only")
         elif key == "code" and "code" in self._data:
             self._change_code(value)
-            print("Successfully switched activity dataset to new code `{}`".format(value))
+            stdout_feedback_logger.info("Successfully switched activity dataset to new code `%s`", value)
         elif key == "database" and "database" in self._data:
             self._change_database(value)
-            print("Successfully switch activity dataset to database `{}`".format(value))
+            stdout_feedback_logger.info("Successfully switch activity dataset to database `%s`", value)
         else:
             super(Activity, self).__setitem__(key, value)
 

--- a/bw2data/backends/utils.py
+++ b/bw2data/backends/utils.py
@@ -29,7 +29,7 @@ def convert_backend(database_name, backend):
     Returns `False` if the old and new backend are the same. Otherwise returns an instance of the new Database object.
     """
     if database_name not in databases:
-        print("Can't find database {}".format(database_name))
+        raise ValueError(f"Can't find database {database_name}")
 
     from bw2data.database import Database
 

--- a/bw2data/backends/wurst_extraction.py
+++ b/bw2data/backends/wurst_extraction.py
@@ -5,6 +5,7 @@ from tqdm import tqdm
 from bw2data.backends import ActivityDataset, ExchangeDataset, SQLiteBackend
 from bw2data.configuration import labels
 from bw2data.database import DatabaseChooser
+from bw2data.logs import stdout_feedback_logger
 
 
 def _list_or_dict(obj):
@@ -159,13 +160,13 @@ def extract_brightway_databases(database_names, add_properties=False, add_identi
     exchange_qs = ExchangeDataset.select().where(ExchangeDataset.output_database << database_names)
 
     # Retrieve all activity data
-    print("Getting activity data")
+    stdout_feedback_logger.info("Getting activity data")
     activities = [extract_activity(o, add_identifiers=add_identifiers) for o in tqdm(activity_qs)]
     # Add each exchange to the activity list of exchanges
-    print("Adding exchange data to activities")
+    stdout_feedback_logger.info("Adding exchange data to activities")
     add_exchanges_to_consumers(activities, exchange_qs, add_properties)
     # Add details on exchanges which come from our databases
-    print("Filling out exchange data")
+    stdout_feedback_logger.info("Filling out exchange data")
     add_input_info_for_indigenous_exchanges(
         activities, database_names, add_identifiers=add_identifiers
     )

--- a/bw2data/data_store.py
+++ b/bw2data/data_store.py
@@ -11,6 +11,7 @@ from fsspec.implementations.zip import ZipFileSystem
 from bw2data import projects
 from bw2data.errors import MissingIntermediateData, UnknownObject
 from bw2data.fatomic import open as atomic_open
+from bw2data.logs import stdout_feedback_logger
 
 
 class DataStore:
@@ -117,7 +118,7 @@ class DataStore:
 
             return BW2Package.export_obj(self)
         except ImportError:
-            print("bw2io not installed")
+            stdout_feedback_logger.warning("bw2io not installed")
 
     def write(self, data):
         """Serialize intermediate data to disk.

--- a/bw2data/logs.py
+++ b/bw2data/logs.py
@@ -1,11 +1,11 @@
+from logging.handlers import RotatingFileHandler
 import codecs
 import datetime
 import logging
-import uuid
-from logging.handlers import RotatingFileHandler
+import sys
+import os
 
-from bw2data import config, projects
-from bw2data.utils import create_in_memory_zipfile_from_directory, random_string
+import structlog
 
 try:
     import anyjson
@@ -24,6 +24,8 @@ class FakeLog:
 
 
 def get_logger(name, level=logging.INFO):
+    from bw2data import projects
+
     filename = "{}-{}.log".format(
         name,
         datetime.datetime.now().strftime("%d-%B-%Y-%I-%M%p"),
@@ -43,8 +45,44 @@ def get_logger(name, level=logging.INFO):
     return logger
 
 
+def get_stdout_feedback_logger(name: str, level: int = logging.INFO):
+    logger = logging.getLogger(name)
+    logger.propagate = False
+    logger.setLevel(level)
+    handler = logging.StreamHandler(sys.stdout)
+    formatter = logging.Formatter('%(asctime)s - %(levelname)s - %(message)s', "%H:%M:%S%z")
+    handler.setFormatter(formatter)
+    logger.addHandler(handler)
+    return logger
+
+
+def get_structlog_stdout_feedback_logger(level: int = logging.INFO):
+    structlog.reset_defaults()
+    structlog.configure(
+        processors=[
+            structlog.contextvars.merge_contextvars,
+            structlog.processors.add_log_level,
+            structlog.processors.StackInfoRenderer(),
+            structlog.dev.set_exc_info,
+            structlog.processors.TimeStamper(fmt="%H:%M:%S%z", utc=False),
+            structlog.dev.ConsoleRenderer()
+        ],
+        wrapper_class=structlog.make_filtering_bound_logger(level),
+        context_class=dict,
+        logger_factory=structlog.PrintLoggerFactory(),
+        cache_logger_on_first_use=True
+    )
+    logger = structlog.get_logger()
+    logger.debug("Starting feedback logger")
+    structlog.reset_defaults()
+    return logger
+
+
 def get_io_logger(name):
     """Build a logger that records only relevent data for display later as HTML."""
+    from bw2data import projects
+    from bw2data.utils import random_string
+
     filepath = projects.logs_dir / "{}.{}.log".format(name, random_string(6))
     handler = logging.StreamHandler(codecs.open(filepath, "w", "utf-8"))
     logger = logging.getLogger(name)
@@ -56,6 +94,8 @@ def get_io_logger(name):
 
 
 def get_verbose_logger(name, level=logging.WARNING):
+    from bw2data import projects
+
     filename = "{}-{}.log".format(
         name,
         datetime.datetime.now().strftime("%d-%B-%Y-%I-%M%p"),
@@ -93,3 +133,9 @@ def close_log(log):
     for handler in handlers:
         handler.close()
         log.removeHandler(handler)
+
+
+if os.getenv("BRIGHTWAY_NO_STRUCTLOG"):
+    stdout_feedback_logger = get_stdout_feedback_logger("brightway-stdout-feedback")
+else:
+    stdout_feedback_logger = get_structlog_stdout_feedback_logger()

--- a/bw2data/project.py
+++ b/bw2data/project.py
@@ -16,6 +16,7 @@ from bw2data.filesystem import create_dir
 from bw2data.signals import project_changed, project_created
 from bw2data.sqlite import PickleField, SubstitutableDatabase
 from bw2data.utils import maybe_path
+from bw2data.logs import stdout_feedback_logger
 
 READ_ONLY_PROJECT = """
 ***Read only project***
@@ -77,7 +78,7 @@ class ProjectManager(Iterable):
 
             MIGRATION_WARNING = """Adding a column to the projects database. A backup copy of this database '{}' was made at '{}'; if you have problems, file an issue, and restore the backup data to use the stable version of Brightway2."""
 
-            print(MIGRATION_WARNING.format(src_filepath, backup_filepath))
+            stdout_feedback_logger.warning(MIGRATION_WARNING.format(src_filepath, backup_filepath))
 
             ADD_FULL_HASH_COLUMN = (
                 """ALTER TABLE projectdataset ADD COLUMN "full_hash" integer default 1"""
@@ -135,7 +136,7 @@ class ProjectManager(Iterable):
                     )
                 )
             else:
-                print(
+                stdout_feedback_logger.info(
                     "Using environment variable BRIGHTWAY2_DIR for data "
                     "directory:\n{}".format(envvar)
                 )
@@ -208,7 +209,7 @@ class ProjectManager(Iterable):
         from bw2data.updates import Updates
 
         for update_name in Updates.check_automatic_updates():
-            print("Applying automatic update: {}".format(update_name))
+            stdout_feedback_logger.info("Applying automatic update: {}".format(update_name))
             Updates.do_update(update_name)
 
     def _reset_meta(self):

--- a/bw2data/sqlite.py
+++ b/bw2data/sqlite.py
@@ -3,6 +3,8 @@ import pickle
 
 from peewee import BlobField, SqliteDatabase, TextField
 
+from bw2data.logs import stdout_feedback_logger
+
 
 class PickleField(BlobField):
     def db_value(self, value):
@@ -45,7 +47,7 @@ class SubstitutableDatabase:
         return self.db.transaction()
 
     def vacuum(self):
-        print("Vacuuming database ")
+        stdout_feedback_logger.info("Vacuuming database ")
         self.execute_sql("VACUUM;")
 
 

--- a/bw2data/updates.py
+++ b/bw2data/updates.py
@@ -23,6 +23,7 @@ from bw2data import (
     weightings,
 )
 from bw2data.backends import sqlite3_lci_db
+from bw2data.logs import stdout_feedback_logger
 
 hash_re = re.compile("^[a-zA-Z0-9]{32}$")
 is_hash = lambda x: bool(hash_re.match(x))
@@ -184,11 +185,11 @@ class Updates:
     @classmethod
     def schema_change_20_compound_keys(cls):
         with sqlite3.connect(sqlite3_lci_db.db.database) as conn:
-            print("Update ActivityDataset table schema and data")
+            stdout_feedback_logger.info("Update ActivityDataset table schema and data")
             conn.executescript(UPDATE_ACTIVITYDATASET)
-            print("Updating ExchangeDataset table schema and data")
+            stdout_feedback_logger.info("Updating ExchangeDataset table schema and data")
             conn.executescript(UPDATE_EXCHANGEDATASET)
-            print("Finished with schema change")
+            stdout_feedback_logger.info("Finished with schema change")
 
     @classmethod
     def database_search_directories_20(cls):
@@ -196,7 +197,7 @@ class Updates:
         for db in databases:
             if databases[db].get("searchable"):
                 databases[db]["searchable"] = False
-                print("Reindexing database {}".format(db))
+                stdout_feedback_logger.info("Reindexing database {}".format(db))
                 Database(db).make_searchable()
 
     @classmethod
@@ -206,7 +207,7 @@ class Updates:
         for db in databases:
             if databases[db].get("searchable"):
                 databases[db]["searchable"] = False
-                print("Reindexing database {}".format(db))
+                stdout_feedback_logger.info("Reindexing database {}".format(db))
                 Database(db).make_searchable()
 
     @classmethod
@@ -232,7 +233,7 @@ class Updates:
         try:
             import bw2io as bi
         except ImportError:
-            print("`bw2io` not installed; not updating `migrations` filenames")
+            stdout_feedback_logger.warning("`bw2io` not installed; not updating `migrations` filenames")
             return
 
         for name in bi.migrations:
@@ -257,7 +258,7 @@ class Updates:
 
         for meta, klass, name in objects:
             if meta.list:
-                print("Updating all %s" % name)
+                stdout_feedback_logger.info("Updating all %s" % name)
 
                 for index, key in tqdm(enumerate(meta)):
                     obj = klass(key)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,6 +42,7 @@ dependencies = [
     "rapidfuzz; sys_platform != 'emscripten'",
     "scipy",
     "stats_arrays",
+    "structlog",
     "tqdm",
     "voluptuous",
     "wrapt",

--- a/tests/compatibility.py
+++ b/tests/compatibility.py
@@ -38,6 +38,7 @@ def test_repr_str_unicode():
     for obj in objects:
         assert repr(obj)
         assert str(obj)
+        # Make sure can be printed - not for debugging
         print(obj)
 
 

--- a/tests/database.py
+++ b/tests/database.py
@@ -445,7 +445,6 @@ def test_processed_array():
         }
     )
     package = database.datapackage()
-    print(package.resources)
     array = package.get_resource("a_database_technosphere_matrix.data")[0]
 
     assert array.shape == (1,)
@@ -534,7 +533,6 @@ def test_processed_array_with_non_process_nodes():
         }
     )
     package = database.datapackage()
-    print(package.resources)
     array = package.get_resource("a_database_technosphere_matrix.data")[0]
 
     assert array.shape == (1,)
@@ -770,9 +768,6 @@ def test_can_split_processes_products():
     # print statements to get debugging for CI test runners
     for x in database:
         print(x.id, x.key, get_id(x.key))
-    print("array:", array)
-    print("array col:", array["col"])
-    print("array dtype:", array.dtype)
     assert array.shape == (1,)
     assert array["col"][0] == get_id(("a database", "foo"))
     assert array["row"][0] == get_id(("a database", "product"))
@@ -798,7 +793,6 @@ def test_sqlite_processed_array_order():
     database.write(data)
     lookup = {k: get_id(("testy_new", k)) for k in "ABC"}
     # print statements to get debugging for CI test runners
-    print("lookup:", lookup)
     assert len(lookup) == 3
     t = sorted(
         [
@@ -813,29 +807,23 @@ def test_sqlite_processed_array_order():
         ]
     )
     b = sorted([(lookup["C"], lookup["B"], 2), (lookup["C"], lookup["B"], 3)])
-    print("t:", t)
-    print("b:", b)
 
     package = database.datapackage()
 
     array = package.get_resource("testy_new_technosphere_matrix.data")[0]
-    print("data array:", array)
     assert array.shape == (6,)
     assert np.allclose(array, [x[2] for x in t])
 
     array = package.get_resource("testy_new_technosphere_matrix.indices")[0]
-    print("indices array:", array)
     assert array.shape == (6,)
     assert np.allclose(array["row"], [x[0] for x in t])
     assert np.allclose(array["col"], [x[1] for x in t])
 
     array = package.get_resource("testy_new_biosphere_matrix.data")[0]
-    print("data array:", array)
     assert array.shape == (2,)
     assert np.allclose(array, [x[2] for x in b])
 
     array = package.get_resource("testy_new_biosphere_matrix.indices")[0]
-    print("indices array:", array)
     assert array.shape == (2,)
     assert np.allclose(array["row"], [x[0] for x in b])
     assert np.allclose(array["col"], [x[1] for x in b])

--- a/tests/geo.py
+++ b/tests/geo.py
@@ -40,7 +40,6 @@ def test_glo_always_present():
 def test_method_process_adds_correct_geo(add_method):
     method = Method(("test method",))
     package = load_datapackage(ZipFileSystem(method.filepath_processed()))
-    print(package.resources)
 
     mapped = {
         row["row"]: row["col"] for row in package.get_resource("test_method_matrix_data.indices")[0]

--- a/tests/ia.py
+++ b/tests/ia.py
@@ -140,7 +140,6 @@ def test_method_processed_array_add_identifier(reset):
     method = Method(("a", "method"))
     method.write([[("foo", "bar"), 42]])
     package = load_datapackage(ZipFileSystem(method.filepath_processed()))
-    print(package.metadata)
     assert package.metadata["resources"][0]["identifier"] == ["a", "method"]
 
 
@@ -224,7 +223,6 @@ def test_weighting_process(reset):
     weighting = Weighting(("foo",))
     weighting.write([42])
     package = load_datapackage(ZipFileSystem(weighting.filepath_processed()))
-    print(package.resources)
 
     data = package.get_resource("foo_matrix_data.data")[0]
     assert np.allclose(data, [42])

--- a/tests/iotable.py
+++ b/tests/iotable.py
@@ -100,7 +100,6 @@ def iotable_fixture():
 
 
 def test_iotable_setup_clean(iotable_fixture):
-    print(databases)
     assert len(databases) == 2
     assert list(methods) == [("a method",)]
     assert len(projects) == 1  # Default project
@@ -133,13 +132,6 @@ def test_iotable_matrix_construction(iotable_fixture):
         ("c", "c", 1, True),
     ]
     for a, b, c, d in tech_values:
-        print(a, b, c, d)
-        print(
-            lca.technosphere_matrix[
-                lca.dicts.product[get_activity(code=a).id],
-                lca.dicts.activity[get_activity(code=b).id],
-            ]
-        )
         assert np.allclose(
             lca.technosphere_matrix[
                 lca.dicts.product[get_activity(code=a).id],
@@ -299,8 +291,6 @@ def test_iotable_nodes_to_dataframe(iotable_fixture):
             },
         ]
     )
-    print(df.reset_index(drop=True))
-    print(expected.reset_index(drop=True))
     assert_frame_equal(
         df.reset_index(drop=True),
         expected.reset_index(drop=True),
@@ -423,7 +413,6 @@ def test_iotable_edges_technosphere(iotable_fixture):
     act = get_activity(("cat", "a"))
     assert len(act.technosphere()) == 1
     exc = next(iter(act.technosphere()))
-    print(exc)
     assert exc.input == get_activity(("cat", "b"))
     assert exc.output == act
     assert isinstance(exc, ReadOnlyExchange)

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -554,7 +554,6 @@ def test_set_correct_process_type():
         ),
     ]
     for ds, label in data:
-        print(ds, label)
         assert set_correct_process_type(ds)["type"] == label
 
 
@@ -593,9 +592,7 @@ def test_set_correct_process_type():
 #     assert len(merged) == 2
 #     assert "another database" not in databases
 #     assert ("a database", "bar") in mapping
-#     print(merged.filepath_processed())
 #     package = load_package(merged.filepath_processed())
-#     print(package.keys())
 #     array = package["technosphere_matrix.npy"]
 #     assert mapping[("a database", "bar")] in {x["col_value"] for x in array}
 #     assert mapping[("a database", "foo")] in {x["col_value"] for x in array}


### PR DESCRIPTION
Partial fix for #189 - replaces all `print` statements in `bw2data` with logging calls.

Uses `structlog` by default, but uses normal logging if env var `BRIGHTWAY_NO_STRUCTLOG` is set to anything truthy.