### PR TITLE
Adapt `add_revision` to its usage in `ab-plugin-onedrive`

### DIFF
--- a/bw2data/project.py
+++ b/bw2data/project.py
@@ -81,7 +81,11 @@ class ProjectDataset(Model):
         self.save()
 
     def add_revision(
-        self, old: Optional[Any], new: Optional[Any], operation: Optional[str] = None
+        self,
+        old: Optional[Any],
+        new: Optional[Any],
+        operation: Optional[str] = None,
+        metadata: Optional[dict[str, Any]] = None,
     ) -> Optional[int]:
         """Add a revision to the project.
 
@@ -117,13 +121,13 @@ class ProjectDataset(Model):
 
         from bw2data import revisions
 
-        metadata = revisions.generate_metadata(parent_revision=self.revision)
+        ext_metadata = revisions.generate_metadata(metadata, parent_revision=self.revision)
         delta = revisions.generate_delta(old, new, operation)
-        self.revision = metadata["revision"]
+        self.revision = ext_metadata["revision"]
         with open(self.dir / "revisions" / f"{self.revision}.rev", "w") as f:
             f.write(
                 revisions.JSONEncoder(indent=2).encode(
-                    revisions.generate_revision(metadata, (delta,)),
+                    revisions.generate_revision(ext_metadata, (delta,)),
                 ),
             )
         self.save()

--- a/bw2data/revisions.py
+++ b/bw2data/revisions.py
@@ -58,7 +58,7 @@ class Delta:
         return obj + self.delta
 
     @classmethod
-    def from_dict(cls: Self, d: dict) -> Self:
+    def from_dict(cls, d: dict) -> Self:
         ret = cls()
         ret.delta = deepdiff.Delta(
             JSONEncoder().encode(d), deserializer=deepdiff.serialization.json_loads
@@ -67,7 +67,7 @@ class Delta:
 
     @classmethod
     def from_difference(
-        cls: Self,
+        cls,
         obj_type: str,
         obj_id: int,
         change_type: str,
@@ -81,7 +81,7 @@ class Delta:
         return ret
 
     @classmethod
-    def _direct_difference(cls: Self, old: dict, new: dict, change_type: str) -> Self:
+    def _direct_difference(cls, old: dict, new: dict, change_type: str) -> Self:
         return cls.from_difference(
             "lci_node",
             old["id"],
@@ -94,18 +94,18 @@ class Delta:
         )
 
     @classmethod
-    def activity_code_change(cls: Self, old: dict, new: dict) -> Self:
+    def activity_code_change(cls, old: dict, new: dict) -> Self:
         """Special handling to change the `database` attribute of an activity node."""
         return cls._direct_difference(old, new, "activity_code_change")
 
     @classmethod
-    def activity_database_change(cls: Self, old: dict, new: dict) -> Self:
+    def activity_database_change(cls, old: dict, new: dict) -> Self:
         """Special handling to change the `database` attribute of an activity node."""
         return cls._direct_difference(old, new, "activity_database_change")
 
     @classmethod
     def generate(
-        cls: Self, old: Optional[Any], new: Optional[Any], operation: Optional[str] = None
+        cls, old: Optional[Any], new: Optional[Any], operation: Optional[str] = None
     ) -> Self:
         """
         Generates a patch object from one version of an object to another.
@@ -196,20 +196,20 @@ class RevisionedORMProxy:
     """
 
     @classmethod
-    def handle(cls: Self, revision_data: dict) -> None:
+    def handle(cls, revision_data: dict) -> None:
         getattr(cls, revision_data["change_type"])(revision_data)
 
     @classmethod
-    def previous_state_as_dict(cls: Self, revision_data: dict) -> dict:
+    def previous_state_as_dict(cls, revision_data: dict) -> dict:
         orm_object = cls.ORM_CLASS.get_by_id(revision_data["id"])
         return cls.orm_as_dict(orm_object)
 
     @classmethod
-    def current_state_as_dict(cls: Self, obj: SignaledDataset) -> dict:
+    def current_state_as_dict(cls, obj: SignaledDataset) -> dict:
         return cls.orm_as_dict(obj)
 
     @classmethod
-    def update(cls: Self, revision_data: dict) -> None:
+    def update(cls, revision_data: dict) -> None:
         previous = cls.previous_state_as_dict(revision_data)
         updated_data = Delta.from_dict(revision_data["delta"]).apply(previous)
         updated_orm_object = cls.ORM_CLASS(**cls.prepare_data_dict_for_orm_class(updated_data))
@@ -217,15 +217,15 @@ class RevisionedORMProxy:
         cls.PROXY_CLASS(document=updated_orm_object).save(signal=False, data_already_set=True)
 
     @classmethod
-    def delete(cls: Self, revision_data: dict) -> None:
+    def delete(cls, revision_data: dict) -> None:
         cls.PROXY_CLASS(cls.ORM_CLASS.get_by_id(revision_data["id"])).delete(signal=False)
 
     @classmethod
-    def prepare_data_dict_for_orm_class(cls: Self, data: dict) -> dict:
+    def prepare_data_dict_for_orm_class(cls, data: dict) -> dict:
         return data
 
     @classmethod
-    def create(cls: Self, revision_data: dict) -> None:
+    def create(cls, revision_data: dict) -> None:
         data = Delta.from_dict(revision_data["delta"]).apply({})
         orm_object = cls.ORM_CLASS(**cls.prepare_data_dict_for_orm_class(data))
         orm_object.id = revision_data["id"]
@@ -240,15 +240,15 @@ class RevisionedNode(RevisionedORMProxy):
     ORM_CLASS = Activity.ORMDataset
 
     @classmethod
-    def orm_as_dict(cls: Self, orm_object: Activity.ORMDataset) -> dict:
+    def orm_as_dict(cls, orm_object: Activity.ORMDataset) -> dict:
         return orm_object.data
 
     @classmethod
-    def prepare_data_dict_for_orm_class(cls: Self, data: dict) -> dict:
+    def prepare_data_dict_for_orm_class(cls, data: dict) -> dict:
         return dict_as_activitydataset(data)
 
     @classmethod
-    def activity_database_change(cls: Self, revision_data: dict) -> None:
+    def activity_database_change(cls, revision_data: dict) -> None:
         """Special handling for changing activity `database` attributes"""
         node = get_node(id=revision_data["id"])
         node._change_database(
@@ -257,7 +257,7 @@ class RevisionedNode(RevisionedORMProxy):
         )
 
     @classmethod
-    def activity_code_change(cls: Self, revision_data: dict) -> None:
+    def activity_code_change(cls, revision_data: dict) -> None:
         """Special handling for changing activity `code` attributes"""
         node = get_node(id=revision_data["id"])
         node._change_code(
@@ -271,7 +271,7 @@ class RevisionedEdge(RevisionedORMProxy):
     ORM_CLASS = Exchange.ORMDataset
 
     @classmethod
-    def orm_as_dict(cls: Self, orm_object: Exchange.ORMDataset) -> dict:
+    def orm_as_dict(cls, orm_object: Exchange.ORMDataset) -> dict:
         return dict_as_exchangedataset(orm_object.data)
 
 

--- a/bw2data/revisions.py
+++ b/bw2data/revisions.py
@@ -54,16 +54,33 @@ class Delta:
     change it to the new state.
     """
 
+    def __init__(
+        self,
+        delta: deepdiff.Delta,
+        obj_type: Optional[str] = None,
+        obj_id: Optional[int] = None,
+        change_type: Optional[str] = None,
+    ):
+        """
+        Private, exists only for type-checking.
+
+        Use one of the class-method constructors to create objects.
+        """
+        self.type = obj_type
+        self.id = obj_id
+        self.change_type = change_type
+        self.delta = delta
+
     def apply(self, obj):
         return obj + self.delta
 
     @classmethod
     def from_dict(cls, d: dict) -> Self:
-        ret = cls()
-        ret.delta = deepdiff.Delta(
-            JSONEncoder().encode(d), deserializer=deepdiff.serialization.json_loads
+        return cls(
+            delta=deepdiff.Delta(
+                JSONEncoder().encode(d), deserializer=deepdiff.serialization.json_loads
+            ),
         )
-        return ret
 
     @classmethod
     def from_difference(
@@ -73,12 +90,12 @@ class Delta:
         change_type: str,
         diff: deepdiff.DeepDiff,
     ) -> Self:
-        ret = cls()
-        ret.type = obj_type
-        ret.id = obj_id
-        ret.change_type = change_type
-        ret.delta = deepdiff.Delta(diff)
-        return ret
+        return cls(
+            obj_type=obj_type,
+            obj_id=obj_id,
+            change_type=change_type,
+            delta=deepdiff.Delta(diff),
+        )
 
     @classmethod
     def _direct_difference(cls, old: dict, new: dict, change_type: str) -> Self:

--- a/bw2data/revisions.py
+++ b/bw2data/revisions.py
@@ -180,16 +180,17 @@ class JSONEncoder(json.JSONEncoder):
 
 
 def generate_metadata(
+    metadata: Optional[dict[str, Any]] = None,
     parent_revision: Optional[int] = None,
     revision: Optional[int] = None,
 ) -> dict[str, Any]:
-    ret = {}
-    ret["parent_revision"] = parent_revision
-    ret["revision"] = revision or next(sfg(0))
-    ret["authors"] = ret.get("authors", "Anonymous")
-    ret["title"] = ret.get("title", "Untitled revision")
-    ret["description"] = ret.get("description", "No description")
-    return ret
+    metadata = metadata or {}
+    metadata["parent_revision"] = parent_revision
+    metadata["revision"] = revision or next(sfg(0))
+    metadata["authors"] = metadata.get("authors", "Anonymous")
+    metadata["title"] = metadata.get("title", "Untitled revision")
+    metadata["description"] = metadata.get("description", "No description")
+    return metadata
 
 
 def generate_revision(metadata: dict, delta: Sequence[Delta]) -> dict:


### PR DESCRIPTION
So that

https://github.com/cauldron/ab-plugin-onedrive/blob/15ed28d4b18bd0483e159f592206f2555f8dc529/ab_plugin_onedrive/plugin.py#L556-L592

can use the function directly and become simply

```python
def commit_changes(self):
    # ...
    title, description = commit_dlg.commit_info()
    metadata = {"title": title, "description": description}
    if username := self._get_current_user():
        metadata["authors"] = username
    bd.projects.dataset.add_revision(self._change_list, metadata)
    self._change_list.clear()
    self.push_changes()
```