### PR TITLE
fix: remove parentheses and curly braces from FTS5 search queries

### DIFF
--- a/bw2data/search/indices.py
+++ b/bw2data/search/indices.py
@@ -100,7 +100,14 @@ class IndexManager:
             if string == "*":
                 query = BW2Schema
             else:
-                query = BW2Schema.search_bm25(string.replace(",", ""), weights=weights)
+                query = BW2Schema.search_bm25(
+                    string.replace(",", "")
+                    .replace("(", "")
+                    .replace(")", "")
+                    .replace("{", "")
+                    .replace("}", ""),
+                    weights=weights,
+                )
             return list(
                 query.select(
                     BW2Schema.name,

--- a/tests/search.py
+++ b/tests/search.py
@@ -337,3 +337,23 @@ def test_search_single_char():
                 "synonyms": "",
             }
         ]
+
+
+@bw2test
+def test_search_with_parentheses():
+    """Test that searching with parentheses works correctly"""
+    im = IndexManager("foo")
+    im.add_dataset({"database": "foo", "code": "bar", "name": "beam dried (u=10%) planed"})
+    with Searcher("foo") as s:
+        assert s.search("dried (u=10%)", proxy=False) == [
+            {
+                "comment": "",
+                "product": "",
+                "name": "beam dried (u=10%) planed",
+                "database": "foo",
+                "location": "",
+                "code": "bar",
+                "categories": "",
+                "synonyms": "",
+            }
+        ]


### PR DESCRIPTION
## Problem
FTS5 search fails with a syntax error when searching for strings containing parentheses () or curly braces {}, as these have special meaning in FTS5 query syntax. 

For example, this search fails with an error:
```python
act = db.search('market for sawnwood, beam, softwood, dried (u=10%), planed')

OperationalError: fts5: syntax error near "dried"
```

This affects searches for product specifications like "dried (u=10%)"

## Solution
Modified the search query to strip parentheses and curly braces before passing to FTS5. This allows the search to work with these special characters while maintaining the search functionality.

## Testing
- Added test case verifying search works with parentheses
- Ran full test suite locally, all tests pass