### PR TITLE
revisions: rebase when necessary

### DIFF
--- a/bw2data/project.py
+++ b/bw2data/project.py
@@ -192,10 +192,8 @@ class ProjectDataset(Model):
                 continue
             with open(self.dir / "revisions" / filename, "r") as f:
                 revs.append(json.load(f))
-        apply_to = self.revision
         g = revisions.RevisionGraph(head, revs)
-        pruned = itertools.takewhile(lambda x: x["metadata"]["revision"] != apply_to, g)
-        for rev in reversed(list(pruned)):
+        for rev in reversed(list(g.range(self.revision, g.head))):
             self.apply_revision(rev)
 
 

--- a/bw2data/revisions.py
+++ b/bw2data/revisions.py
@@ -118,6 +118,10 @@ class RevisionGraph:
         p = self.id_map[r0]
         return itertools.takewhile(lambda x: x is not p, i)
 
+    def is_ancestor(self, parent: Optional[ID], child: ID) -> bool:
+        """Checks whether a revision can be reached by another."""
+        return parent is None or self.id_map[parent] in self.range(child)
+
     def merge_base(
         self,
         revision0: Optional[ID],

--- a/bw2data/revisions.py
+++ b/bw2data/revisions.py
@@ -1,5 +1,5 @@
 import json
-from typing import Any, Optional, Sequence, Union
+from typing import TYPE_CHECKING, Any, Iterator, Optional, Sequence, Union
 
 import deepdiff
 
@@ -26,6 +26,13 @@ try:
 except ImportError:
     from typing_extensions import Self
 
+if TYPE_CHECKING:
+    import typing
+
+
+ID = int
+Revision = dict
+
 
 class RevisionGraph:
     """Graph of revisions, edges are based on `metadata.parent_revision`."""
@@ -33,9 +40,12 @@ class RevisionGraph:
     class Iterator:
         """Helper class implementing iteration from child to parent."""
 
-        def __init__(self, g: "RevisionGraph"):
-            self.head = g.head
+        def __init__(self, g: "RevisionGraph", head: Optional[ID] = None):
+            self.head: Optional[ID] = head if head is not None else g.head
             self.id_map = g.id_map
+
+        def __iter__(self) -> "typing.Iterator":
+            return self
 
         def __next__(self) -> Optional[dict]:
             if self.head is None:
@@ -44,7 +54,7 @@ class RevisionGraph:
             self.head = ret["metadata"].get("parent_revision")
             return ret
 
-    def __init__(self, head: int, revisions: Sequence[dict]):
+    def __init__(self, head: ID, revisions: Sequence[Revision]):
         self.head = head
         self.revisions = revisions
         self.id_map = {r["metadata"]["revision"]: r for r in revisions}


### PR DESCRIPTION
- revisions: allow iterator to be used independently
- revisions: add commit range function
- revisions: add a rebase operation
- revisions: add a merge base query
- revisions: extract functions
- revisions: rebase when necessary

---

~Last bit is untested, but opening as a draft for early review.~

Note that since the delta only store forward information, it is not possible to do a truly safe rebase, as that would require resetting to an early common ancestor and (re-)applying the two diverging branches. This version simply optimistically assumes there are no conflicts (**n.b.**: the database and the revision history will be inconsistent if there is).