### PR TITLE
revisions: fix (some) type annotations

### DIFF
--- a/bw2data/backends/proxies.py
+++ b/bw2data/backends/proxies.py
@@ -1,7 +1,7 @@
 import copy
 import uuid
 from collections.abc import Iterable
-from typing import Callable, List, Optional
+from typing import Callable, List, Optional, TypeAlias
 
 import pandas as pd
 
@@ -186,7 +186,7 @@ class Exchanges(Iterable):
 
 
 class Activity(ActivityProxyBase):
-    ORMDataset = ActivityDataset
+    ORMDataset: TypeAlias = ActivityDataset
 
     def __init__(self, document=None, **kwargs):
         """Create an `Activity` proxy object.
@@ -556,7 +556,7 @@ class Activity(ActivityProxyBase):
 
 
 class Exchange(ExchangeProxyBase):
-    ORMDataset = ExchangeDataset
+    ORMDataset: TypeAlias = ExchangeDataset
 
     def __init__(self, document=None, **kwargs):
         """Create an `Exchange` proxy object.

--- a/bw2data/data_store.py
+++ b/bw2data/data_store.py
@@ -1,4 +1,5 @@
 import pickle
+from abc import abstractmethod
 
 from bw_processing import (
     clean_datapackage_name,
@@ -147,6 +148,24 @@ class ProcessedDataStore(DataStore):
     """
 
     matrix = "unknown"
+
+    @abstractmethod
+    def make_searchable(self, reset: bool = False, signal: bool = True) -> bool:
+        pass
+
+    @abstractmethod
+    def make_unsearchable(self, signal: bool = False) -> bool:
+        pass
+
+    @abstractmethod
+    def delete(
+        self,
+        keep_params: bool = False,
+        warn: bool = True,
+        vacuum: bool = True,
+        signal: bool = True,
+    ):
+        pass
 
     def dirpath_processed(self):
         return projects.dir / "processed"


### PR DESCRIPTION
It's very onerous to try to work on these files and mentally filter these:

<details>

```
$ make mypy TARGET='bw2data/{project,revisions}.py'
mypy --follow-imports skip bw2data/{project,revisions}.py tests/unit/test_events.py
bw2data/revisions.py:5: error: Skipping analyzing "deepdiff": module is installed, but missing library stubs or py.typed marker  [import-untyped]
bw2data/revisions.py:265: error: "type[object]" has no attribute "current_state_as_dict"  [attr-defined]
bw2data/revisions.py:266: error: "type[object]" has no attribute "current_state_as_dict"  [attr-defined]
bw2data/revisions.py:270: error: Incompatible return value type (got "None", expected "Self")  [return-value]
bw2data/revisions.py:274: error: Item "None" of "Any | None" has no attribute "id"  [union-attr]
bw2data/revisions.py:329: error: "type[RevisionedORMProxy]" has no attribute "ORM_CLASS"  [attr-defined]
bw2data/revisions.py:330: error: "type[RevisionedORMProxy]" has no attribute "orm_as_dict"  [attr-defined]
bw2data/revisions.py:334: error: "type[RevisionedORMProxy]" has no attribute "orm_as_dict"  [attr-defined]
bw2data/revisions.py:340: error: "type[RevisionedORMProxy]" has no attribute "ORM_CLASS"  [attr-defined]
bw2data/revisions.py:342: error: "type[RevisionedORMProxy]" has no attribute "PROXY_CLASS"  [attr-defined]
bw2data/revisions.py:346: error: "type[RevisionedORMProxy]" has no attribute "PROXY_CLASS"  [attr-defined]
bw2data/revisions.py:346: error: "type[RevisionedORMProxy]" has no attribute "ORM_CLASS"  [attr-defined]
bw2data/revisions.py:355: error: "type[RevisionedORMProxy]" has no attribute "ORM_CLASS"  [attr-defined]
bw2data/revisions.py:358: error: "type[RevisionedORMProxy]" has no attribute "PROXY_CLASS"  [attr-defined]
bw2data/revisions.py:366: error: "type[RevisionedParameter]" has no attribute "KEYS"  [attr-defined]
bw2data/revisions.py:374: error: "type[RevisionedParameter]" has no attribute "ORM_CLASS"  [attr-defined]
bw2data/revisions.py:381: error: "type[RevisionedParameter]" has no attribute "ORM_CLASS"  [attr-defined]
bw2data/revisions.py:387: error: "type[RevisionedParameter]" has no attribute "ORM_CLASS"  [attr-defined]
bw2data/revisions.py:392: error: "type[RevisionedParameter]" has no attribute "ORM_CLASS"  [attr-defined]
bw2data/project.py:12: error: Skipping analyzing "deepdiff": module is installed, but missing library stubs or py.typed marker  [import-untyped]
bw2data/project.py:12: note: See https://mypy.readthedocs.io/en/stable/running_mypy.html#missing-imports
bw2data/project.py:13: error: Skipping analyzing "wrapt": module is installed, but missing library stubs or py.typed marker  [import-untyped]
bw2data/project.py:14: error: Skipping analyzing "bw_processing": module is installed, but missing library stubs or py.typed marker  [import-untyped]
bw2data/project.py:15: error: Library stubs not installed for "peewee"  [import-untyped]
bw2data/project.py:15: note: Hint: "python3 -m pip install types-peewee"
bw2data/project.py:15: note: (or run "mypy --install-types" to install all missing stub packages)
bw2data/project.py:143: error: "type[object]" has no attribute "handle"  [attr-defined]
Found 24 errors in 2 files (checked 3 source files)
make: *** [Makefile:11: mypy] Error 1
```

</details>

These changes move a bit in a more pleasant direction by fixing all errors from these two files which are strictly annotation problems. There is still one error related to `REVISIONED_LABEL_AS_OBJECT` values being used for two purposes while `RevisionedDatabase` supports only one of them (a `TODO` is now there to mark it), but 1 is better than 24.