### PR TITLE
fix: escape search strings properly for SQLite FTS5 format

### DIFF
--- a/bw2data/search/schema.py
+++ b/bw2data/search/schema.py
@@ -13,4 +13,4 @@ class BW2Schema(FTS5Model):
     code = SearchField()
 
     class Meta:
-        options = {"tokenize": "unicode61 tokenchars '''&:'"}
+        options = {"tokenize": "unicode61"}


### PR DESCRIPTION
## :wrench: Problem

Searching for strings containing special characters like `'` or `/` don't return the expected results. The SQL string has been partially and manually escaped in this commit https://github.com/brightway-lca/brightway2-data/commit/4fd8e9388085abb9208b66f520f0e147bf3e5e7c but it doesn't take into account all the possible cases of the [FTS5 syntax](https://sqlite.org/fts5.html).

The underlying problem was introduced by this change https://github.com/brightway-lca/brightway2-data/compare/4.0.dev47...4.0.dev50#diff-1fbc7247b695dcdd691f024bc0710608aa363a7be05a2b420a19cacdaa6e70cdR16 that changes the tokenizer from `porter` to a custom `unicode61` tokenizer with some special chars considered as tokens (`'`, `&` and `:`).

## :cake: Solution

Use the default `unicode61` tokenizer and properly escape the query terms by using `""` SQL escape sequence, see https://stackoverflow.com/a/43756146 for more context.

## :rotating_light:  Points to watch/comments

I don't know the reason for switching from `porter` to `unicode61` for the tokenizer so I may be missing something here.

The search query `Com* cheese cow's` will be converted to `"com"* "cheese" "cow's"`.

As it seems that the `*` character was used as a wildcard, I’ve kept the compatibility when used at the end of a word. Using it in the middle of a word will fail as it will be treated as a normal character (escaped thanks to '""'). 

## :desert_island: How to test

Unit tests have been added, but testing it with real data may be useful.
