### PR TITLE
Fix type annotations in Python 3.9

### DIFF
--- a/bw2data/backends/proxies.py
+++ b/bw2data/backends/proxies.py
@@ -1,7 +1,8 @@
 import copy
 import uuid
 from collections.abc import Iterable
-from typing import Callable, List, Optional, TypeAlias
+import sys
+from typing import Callable, List, Optional
 
 import pandas as pd
 
@@ -21,6 +22,11 @@ from bw2data.logs import stdout_feedback_logger
 from bw2data.proxies import ActivityProxyBase, ExchangeProxyBase
 from bw2data.search import IndexManager
 from bw2data.signals import on_activity_code_change, on_activity_database_change
+
+if sys.version_info < (3, 10):
+    from typing_extensions import TypeAlias
+else:
+    from typing import TypeAlias
 
 
 class Exchanges(Iterable):

--- a/bw2data/revisions.py
+++ b/bw2data/revisions.py
@@ -1,5 +1,6 @@
 import itertools
 import json
+import sys
 from typing import (
     TYPE_CHECKING,
     Any,
@@ -8,7 +9,6 @@ from typing import (
     Iterator,
     Optional,
     Sequence,
-    TypeAlias,
     TypeVar,
     Union,
 )
@@ -33,10 +33,14 @@ from bw2data.signals import SignaledDataset
 from bw2data.snowflake_ids import snowflake_id_generator
 from bw2data.utils import get_node
 
-try:
-    from typing import Self
-except ImportError:
+if sys.version_info < (3, 10):
+    from typing_extensions import TypeAlias
+else:
+    from typing import TypeAlias
+if sys.version_info < (3, 11):
     from typing_extensions import Self
+else:
+    from typing import Self
 
 if TYPE_CHECKING:
     import typing


### PR DESCRIPTION
`TypeAlias` was introduced in 3.10.