### PR TITLE
fix: add signal parameter to write method in IOTableBackend

### DIFF
--- a/bw2data/backends/iotable/backend.py
+++ b/bw2data/backends/iotable/backend.py
@@ -21,8 +21,8 @@ class IOTableBackend(SQLiteBackend):
     backend = "iotable"
     node_class = IOTableActivity
 
-    def write(self, data, process=False, searchable=True, check_typos=True):
-        super().write(data, process=False, searchable=searchable, check_typos=check_typos)
+    def write(self, data, process=False, searchable=True, check_typos=True, signal=None):
+        super().write(data, process=False, searchable=searchable, check_typos=check_typos, signal=signal)
 
     def write_exchanges(self, technosphere, biosphere, dependents):
         """


### PR DESCRIPTION
Fix TypeError in IOTableBackend.write due to missing 'signal' argument

```bash
---------------------------------------------------------------------------
TypeError                                 Traceback (most recent call last)
Cell In[17], line 5
      1 pet_example = IOImporter(dirpath=path_to_intermediate,
      2                          db_name='pet_io_db',
      3                          b3mapping=biosphere_mapping)
      4 pet_example.apply_strategies()
----> 5 pet_example.write_database()

File ~/Projects/Personal/fix-io/brightway2-io/bw2io/importers/io.py:112, in IOImporter.write_database(self, biosphere)
    110 assert main_biosphere in bd.databases,'target biosphere db missing'
    111 # write the metadata
--> 112 self.write_activities_as_database()
    113 add_product_ids(self.products,self.db_name)
    115 # product unique code to id

File ~/Projects/Personal/fix-io/brightway2-io/bw2io/importers/io.py:97, in IOImporter.write_activities_as_database(self)
     94     data[key] = d
     96 if self.db_name not in bd.databases:
---> 97     db.register(format="EXIOBASE 3", filepath=str(self.dirpath))
     99 db.write(data)

File ~/Projects/Personal/fix-io/brightway2-io/.venv/lib/python3.11/site-packages/bw2data/backends/base.py:311, in SQLiteBackend.register(self, write_empty, **kwargs)
    309 super().register(**kwargs)
    310 if write_empty:
--> 311     self.write({}, searchable=False, signal=False)

TypeError: IOTableBackend.write() got an unexpected keyword argument 'signal'
```

The `SQLiteBackend.register` method calls `self.write`, passing the `signal` keyword argument. However, the overridden `IOTableBackend.write` method did not accept this argument, leading to a `TypeError: IOTableBackend.write() got an unexpected keyword argument 'signal'`.

This commit updates the `IOTableBackend.write` method to include the optional `signal` argument and passes it to the `super().write` call, resolving the incompatibility with the parent class method.