### PR TITLE
Adding memoization (cache) to 'get_id()', saves 1 minute per ecoinvent import.

### DIFF
--- a/bw2data/backends/schema.py
+++ b/bw2data/backends/schema.py
@@ -1,3 +1,5 @@
+from functools import cache
+
 from peewee import DoesNotExist, TextField
 
 from bw2data.errors import UnknownObject
@@ -27,7 +29,7 @@ class ExchangeDataset(SnowflakeIDBaseClass):
     output_database = TextField()  # Canonical
     type = TextField()  # Reset from `data`
 
-
+@cache
 def get_id(key):
     if isinstance(key, int):
         try:


### PR DESCRIPTION
Adding simple memoization (memory cache) to `get_id()` enables to save 1 minute on the import of ecoinvent.
get_id() was doing a lot of queries to Sqlite Db.

Once we get a Peewee Dataset from an ID, it won't change and we can safely get it back from memory without requiring a SQL query.
