### PR TITLE
Improve import time and diskspace

### DIFF
--- a/bw2data/backends/base.py
+++ b/bw2data/backends/base.py
@@ -13,12 +13,13 @@ import pandas
 from bw_processing import Datapackage, clean_datapackage_name, create_datapackage
 from fsspec.implementations.zip import ZipFileSystem
 from peewee import JOIN, DoesNotExist, fn
+from sympy.physics.units import vacuum_impedance
 from tqdm import tqdm
 
 from bw2data import calculation_setups, config, databases, geomapping
 from bw2data.backends import sqlite3_lci_db
 from bw2data.backends.proxies import Activity
-from bw2data.backends.schema import ActivityDataset, ExchangeDataset, get_id
+from bw2data.backends.schema import ActivityDataset, ExchangeDataset, get_id, insert_many_exchanges, insert_many_activities
 from bw2data.backends.typos import (
     check_activity_keys,
     check_activity_type,
@@ -32,7 +33,7 @@ from bw2data.backends.utils import (
     get_csv_data_dict,
     retupleize_geo_strings,
 )
-from bw2data.configuration import labels
+from bw2data.configuration import labels, Config
 from bw2data.data_store import ProcessedDataStore
 from bw2data.errors import (
     DuplicateNode,
@@ -45,10 +46,12 @@ from bw2data.logs import stdout_feedback_logger
 from bw2data.query import Query
 from bw2data.search import IndexManager, Searcher
 from bw2data.signals import on_database_reset, on_database_write
+from bw2data.snowflake_ids import snowflake_id_generator, snowflake_to_code
 from bw2data.utils import as_uncertainty_dict, get_geocollection, get_node, set_correct_process_type
 
 _VALID_KEYS = {"location", "name", "product", "type"}
 
+CHUNK_SIZE = 500
 
 def tqdm_wrapper(iterable, is_test):
     if is_test:
@@ -57,20 +60,22 @@ def tqdm_wrapper(iterable, is_test):
         return tqdm(iterable)
 
 
-def get_technosphere_qs(database_name: str, edge_types: Iterable[str]) -> Iterable:
+def generic_select(database_name: str, edge_types: Iterable[str]) -> Iterable:
     Source = ActivityDataset.alias()
     Target = ActivityDataset.alias()
-    return (
-        ExchangeDataset.select(
-            ExchangeDataset.data,
+    query = (ExchangeDataset.select(
+            ExchangeDataset.type,
+            ExchangeDataset.amount,
+            ExchangeDataset.uncertainty_type,
+            ExchangeDataset.loc,
+            ExchangeDataset.scale,
+            ExchangeDataset.shape,
+            ExchangeDataset.minimum,
+            ExchangeDataset.maximum,
             Source.id,
             Target.id,
             ExchangeDataset.input_database,
-            ExchangeDataset.input_code,
-            ExchangeDataset.output_database,
-            ExchangeDataset.output_code,
-        )
-        .join(
+        ).join(
             Source,
             # Use a left join to get invalid edges and raise error
             join_type=JOIN.LEFT_OUTER,
@@ -92,58 +97,20 @@ def get_technosphere_qs(database_name: str, edge_types: Iterable[str]) -> Iterab
             (ExchangeDataset.output_database == database_name)
             & (ExchangeDataset.type << edge_types)
             & (Target.type << labels.process_node_types)
-        )
-        .tuples()
-        .iterator()
-    )
+        ))
 
+    # Use raw SQlite request (no need to go trough Peewee ORM here)
+    sql, params = query.sql()
+    res = ExchangeDataset._meta.database.execute_sql(sql, params).fetchall()
+    return res
 
-get_technosphere_positive_qs = partial(
-    get_technosphere_qs, edge_types=labels.technosphere_positive_edge_types
-)
-get_technosphere_negative_qs = partial(
-    get_technosphere_qs, edge_types=labels.technosphere_negative_edge_types
-)
+technosphere_positive_edges = set(labels.technosphere_positive_edge_types)
+technosphere_negative_edges = set(labels.technosphere_negative_edge_types)
+technosphere_edges = technosphere_negative_edges | technosphere_positive_edges
 
+get_biosphere_qs = partial(generic_select, edge_types=labels.biosphere_edge_types)
+get_technosphere_qs = partial(generic_select, edge_types=technosphere_edges)
 
-def get_biosphere_qs(database_name: str) -> Iterable:
-    Source = ActivityDataset.alias()
-    Target = ActivityDataset.alias()
-    return (
-        ExchangeDataset.select(
-            ExchangeDataset.data,
-            Source.id,
-            Target.id,
-            ExchangeDataset.input_database,
-            ExchangeDataset.input_code,
-            ExchangeDataset.output_database,
-            ExchangeDataset.output_code,
-        )
-        .join(
-            Source,
-            join_type=JOIN.LEFT_OUTER,
-            on=(
-                (ExchangeDataset.input_code == Source.code)
-                & (ExchangeDataset.input_database == Source.database)
-            ),
-        )
-        .switch(ExchangeDataset)
-        .join(
-            Target,
-            join_type=JOIN.LEFT_OUTER,
-            on=(
-                (ExchangeDataset.output_code == Target.code)
-                & (ExchangeDataset.output_database == Target.database)
-            ),
-        )
-        .where(
-            (ExchangeDataset.output_database == database_name)
-            & (ExchangeDataset.type << labels.biosphere_edge_types)
-            & (Target.type << labels.process_node_types)
-        )
-        .tuples()
-        .iterator()
-    )
 
 
 class SQLiteBackend(ProcessedDataStore):
@@ -580,6 +547,7 @@ class SQLiteBackend(ProcessedDataStore):
     def _drop_indices(self):
         with sqlite3_lci_db.transaction():
             sqlite3_lci_db.execute_sql('DROP INDEX IF EXISTS "activitydataset_key"')
+            sqlite3_lci_db.execute_sql('DROP INDEX IF EXISTS "activitydataset_type"')
             sqlite3_lci_db.execute_sql('DROP INDEX IF EXISTS "exchangedataset_input"')
             sqlite3_lci_db.execute_sql('DROP INDEX IF EXISTS "exchangedataset_output"')
 
@@ -589,58 +557,64 @@ class SQLiteBackend(ProcessedDataStore):
                 'CREATE UNIQUE INDEX IF NOT EXISTS "activitydataset_key" ON "activitydataset" ("database", "code")'
             )
             sqlite3_lci_db.execute_sql(
+                'CREATE INDEX IF NOT EXISTS "activitydataset_type" ON "activitydataset" ("type")'
+            )
+            sqlite3_lci_db.execute_sql(
                 'CREATE INDEX IF NOT EXISTS "exchangedataset_input" ON "exchangedataset" ("input_database", "input_code")'
             )
             sqlite3_lci_db.execute_sql(
                 'CREATE INDEX IF NOT EXISTS "exchangedataset_output" ON "exchangedataset" ("output_database", "output_code")'
             )
 
-    def _efficient_write_dataset(
+    def _efficient_write_datasets(
         self,
-        ds: dict,
-        exchanges: list,
-        activities: list,
+        datasets: list,
         check_typos: bool = True,
-    ) -> (list, list):
-        for exchange in ds.get("exchanges", []):
-            if "input" not in exchange or "amount" not in exchange:
-                raise InvalidExchange
-            if "type" not in exchange:
-                raise UntypedExchange
+        drop_meta_data= True):
+
+        # Extract all exchanges
+        exchanges = []
+        activities = []
+
+        for ds in datasets:
+
+            for exchange in ds.get("exchanges", []):
+                if "input" not in exchange or "amount" not in exchange:
+                    raise InvalidExchange
+                if "type" not in exchange:
+                    raise UntypedExchange
+
+                if check_typos:
+                    check_exchange_type(exchange.get("type"))
+                    check_exchange_keys(exchange)
+
+                if "output" not in exchange:
+                    exchange["output"] = (ds["database"], ds["code"])
+                exchanges.append(dict_as_exchangedataset(exchange))
+
+
+            # Extract activity without exchange
+            ds = {k: v for k, v in ds.items() if k != "exchanges"}
 
             if check_typos:
-                check_exchange_type(exchange.get("type"))
-                check_exchange_keys(exchange)
+                check_activity_type(ds.get("type"))
+                check_activity_keys(ds)
 
-            if "output" not in exchange:
-                exchange["output"] = (ds["database"], ds["code"])
-            exchanges.append(dict_as_exchangedataset(exchange))
+            activities.append(dict_as_activitydataset(ds, add_snowflake_id=True))
 
-            # Query gets passed as INSERT INTO x VALUES ('?', '?'...)
-            # SQLite3 has a limit of 999 variables,
-            # So 6 fields * 125 is under the limit
-            # Otherwise get the following:
-            # peewee.OperationalError: too many SQL variables
-            if len(exchanges) > 125:
-                ExchangeDataset.insert_many(exchanges).execute()
-                exchanges = []
+        # Insert activities and exchanges for this chunk
+        insert_many_activities(activities, drop_meta_data=drop_meta_data)
+        insert_many_exchanges(exchanges, drop_meta_data=drop_meta_data)
 
-        ds = {k: v for k, v in ds.items() if k != "exchanges"}
-
-        if check_typos:
-            check_activity_type(ds.get("type"))
-            check_activity_keys(ds)
-
-        activities.append(dict_as_activitydataset(ds, add_snowflake_id=True))
-
-        if len(activities) > 125:
-            ActivityDataset.insert_many(activities).execute()
-            activities = []
-
-        return exchanges, activities
 
     def _efficient_write_many_data(
-        self, data: list, indices: bool = True, check_typos: bool = True
+        self,
+        data: list,
+        indices: bool = True,
+        check_typos: bool = True,
+        drop_meta_data = True,
+        vacuum =True
+
     ) -> None:
         be_complicated = len(data) >= 100 and indices
         if be_complicated:
@@ -649,19 +623,21 @@ class SQLiteBackend(ProcessedDataStore):
         try:
             sqlite3_lci_db.db.begin()
             self.delete(keep_params=True, warn=False, vacuum=False)
-            exchanges, activities = [], []
 
-            for ds in tqdm_wrapper(data, getattr(config, "is_test", False)):
-                exchanges, activities = self._efficient_write_dataset(
-                    ds, exchanges, activities, check_typos
-                )
+            # Split in chunks
+            for i in tqdm(range(0, len(data), CHUNK_SIZE), desc="Insert into database"):
+                chunk = data[i:i + CHUNK_SIZE]
 
-            if activities:
-                ActivityDataset.insert_many(activities).execute()
-            if exchanges:
-                ExchangeDataset.insert_many(exchanges).execute()
+                self._efficient_write_datasets(
+                    datasets=chunk,
+                    check_typos=check_typos,
+                    drop_meta_data=drop_meta_data)
+
+
             sqlite3_lci_db.db.commit()
-            sqlite3_lci_db.vacuum()
+
+            if vacuum:
+                sqlite3_lci_db.vacuum()
         except:
             sqlite3_lci_db.db.rollback()
             raise
@@ -670,6 +646,7 @@ class SQLiteBackend(ProcessedDataStore):
             if be_complicated:
                 self._add_indices()
 
+
     # Public API
 
     def write(
@@ -677,9 +654,10 @@ class SQLiteBackend(ProcessedDataStore):
         data: Union[dict, list],
         process: bool = True,
         searchable: bool = True,
-        check_typos: bool = True,
-        signal: Optional[bool] = None,
-    ):
+        check_typos: bool = False,
+        drop_meta_data: bool = None,
+        signal: Optional[bool] = None):
+
         """Write ``data`` to database.
 
         ``data`` must be a dictionary of the form::
@@ -706,6 +684,16 @@ class SQLiteBackend(ProcessedDataStore):
 
         if self.name not in databases:
             self.register(write_empty=False)
+
+        # Vacuum not needed if db was empty
+        vacuum = len(self) > 0
+
+        # If drop_meta_data not provided, take it from global config
+        if drop_meta_data is None:
+            drop_meta_data = config.drop_metadata
+        if drop_meta_data:
+            stdout_feedback_logger.info("Dropping extra meta data")
+
         wrong_database = {ds["database"] for ds in data}.difference({self.name})
         if wrong_database:
             raise WrongDatabase(
@@ -733,7 +721,11 @@ class SQLiteBackend(ProcessedDataStore):
         geomapping.add({x["location"] for x in data if x.get("location")})
         if data:
             try:
-                self._efficient_write_many_data(data, check_typos=check_typos)
+                self._efficient_write_many_data(
+                    data,
+                    check_typos=check_typos,
+                    drop_meta_data=drop_meta_data,
+                    vacuum=vacuum)
             except:
                 # Purge all data from database, then reraise
                 self.delete(warn=False, signal=signal)
@@ -951,7 +943,7 @@ Here are the type values usually used for nodes:
         if signal:
             on_database_reset.send(name=self.name)
 
-    def exchange_data_iterator(self, qs_func, dependents, flip=False):
+    def exchange_data_iterator(self, qs_func, dependents):
         """Iterate over exchanges and format for ``bw_processing`` arrays.
 
         ``dependents`` is a set of dependent database names.
@@ -961,25 +953,46 @@ Here are the type values usually used for nodes:
         Uses raw sqlite3 to retrieve data for ~2x speed boost."""
         for line in qs_func(self.name):
             (
-                data,
+                type,
+                amount,
+                uncertainty_type,
+                loc,
+                scale,
+                shape,
+                minimum,
+                maximum,
                 row,
                 col,
-                input_database,
-                input_code,
-                output_database,
-                output_code,
-            ) = line
+                input_database) = line
+
+            # This simulate numerical info being nested in 'data'.
+            data=dict(
+                type=type,
+                amount=amount,
+                loc=loc,
+                scale=scale,
+                shape=shape,
+                minimum=minimum,
+                maximum=maximum)
+
+            if uncertainty_type is not None :
+                data["uncertainty_type"] = uncertainty_type
+
             # Modify ``dependents`` in place
-            if input_database != output_database:
+            if input_database != self.name:
                 dependents.add(input_database)
-            check_exchange(data)
+
+            #check_exchange(data)
+
+            flip = (type in technosphere_negative_edges)
+
             if row is None or col is None:
                 raise UnknownObject(
                     (
                         "Exchange between {} and {} is invalid "
                         "- one of these objects is unknown (i.e. doesn't exist "
                         "as a process dataset)"
-                    ).format((input_database, input_code), (output_database, output_code))
+                    ).format((row), (col))
                 )
             yield {
                 **as_uncertainty_dict(data),
@@ -1057,9 +1070,9 @@ Here are the type values usually used for nodes:
 
         # Figure out when the production exchanges are implicit
         implicit_production = (
-            {"row": get_id((self.name, x[0])), "amount": 1}
+            {"row": item.id, "amount": 1}
             # Get all codes
-            for x in ActivityDataset.select(ActivityDataset.code)
+            for item in ActivityDataset.select(ActivityDataset.id)
             .where(
                 # Get correct database name
                 ActivityDataset.database == self.name,
@@ -1076,19 +1089,15 @@ Here are the type values usually used for nodes:
                         ExchangeDataset.type << labels.technosphere_positive_edge_types,
                     )
                 ),
-            )
-            .tuples()
-        )
+            ))
 
         dp.add_persistent_vector_from_iterator(
             matrix="technosphere_matrix",
             name=clean_datapackage_name(self.name + " technosphere matrix"),
             dict_iterator=itertools.chain(
-                self.exchange_data_iterator(get_technosphere_negative_qs, dependents, flip=True),
-                self.exchange_data_iterator(get_technosphere_positive_qs, dependents),
-                implicit_production,
-            ),
-        )
+                self.exchange_data_iterator(get_technosphere_qs, dependents),
+                implicit_production))
+
         if csv:
             df = pandas.DataFrame([get_csv_data_dict(ds) for ds in self])
             dp.add_csv_metadata(

--- a/bw2data/backends/iotable/backend.py
+++ b/bw2data/backends/iotable/backend.py
@@ -21,7 +21,7 @@ class IOTableBackend(SQLiteBackend):
     backend = "iotable"
     node_class = IOTableActivity
 
-    def write(self, data, process=False, searchable=True, check_typos=True, signal=None):
+    def write(self, data, process=False, searchable=True, check_typos=False, signal=None):
         super().write(
             data, process=False, searchable=searchable, check_typos=check_typos, signal=signal
         )

--- a/bw2data/backends/schema.py
+++ b/bw2data/backends/schema.py
@@ -1,33 +1,83 @@
 from functools import cache
 
-from peewee import DoesNotExist, TextField
+from peewee import DoesNotExist, TextField, FloatField, IntegerField, Model, Function
+from playhouse.signals import pre_save, pre_init
 
+from bw2data.sqlite import CleanJSONField, spread_data_into_fields, add_field_into_data, FastJSONField
 from bw2data.errors import UnknownObject
 from bw2data.snowflake_ids import SnowflakeIDBaseClass
-from bw2data.sqlite import PickleField
+
 
 
 class ActivityDataset(SnowflakeIDBaseClass):
-    data = PickleField()  # Canonical, except for other C fields
+    data = CleanJSONField(default=dict)  # Set just after
     code = TextField()  # Canonical
-    database = TextField()  # Canonical
+    comment = TextField(null=True)
+    categories = FastJSONField(null=True)
+    synonyms = FastJSONField(null=True)
+    database = TextField() # EnumField(DatabaseEnum)
+    unit = TextField(null=True) # EnumField(UnitEnum, null=True)
     location = TextField(null=True)  # Reset from `data`
     name = TextField(null=True)  # Reset from `data`
     product = TextField(null=True)  # Reset from `data`
-    type = TextField(null=True)  # Reset from `data`
+    type = TextField(null=True) # EnumField(TypeEnum, null=True)  # Reset from `data`
+
+    class Meta:
+        extra_data_mapping = {"reference product": "product"}
+
 
     @property
     def key(self):
         return (self.database, self.code)
 
+ActivityDataset.data.setup_model(ActivityDataset)
 
 class ExchangeDataset(SnowflakeIDBaseClass):
-    data = PickleField()  # Canonical, except for other C fields
+    data = CleanJSONField(default=dict)   # Canonical, except for other C fields
+    amount= FloatField(null=True)
+    scale = FloatField(null=True)
+    shape = FloatField(null=True)
+    loc = FloatField(null=True)
+    uncertainty_type = IntegerField(null=True)
+    minimum = FloatField(null=True)
+    maximum = FloatField(null=True)
+
+    unit = TextField(null=True) # EnumField(UnitEnum, null=True)
+
+    name= TextField(null=True)
     input_code = TextField()  # Canonical
-    input_database = TextField()  # Canonical
+    input_database = TextField() # EnumField(DatabaseEnum)
     output_code = TextField()  # Canonical
-    output_database = TextField()  # Canonical
-    type = TextField()  # Reset from `data`
+    output_database = TextField() # EnumField(DatabaseEnum)
+    type = TextField(null=True) # EnumField(TypeEnum, null=True)  # Reset from `data`
+
+    class Meta:
+        extra_data_mapping = {
+            "uncertainty type" : "uncertainty_type",
+            "input" : ("input_database", "input_code"),
+            "output" : ("output_database", "output_code")}
+
+
+ExchangeDataset.data.setup_model(ExchangeDataset)
+
+
+@pre_save(sender=ActivityDataset)
+def activity_pre_save(model_class, instance, created):
+    spread_data_into_fields(model_class, instance)
+
+@pre_save(sender=ExchangeDataset)
+def exchange_pre_save(model_class, instance, created):
+    spread_data_into_fields(model_class, instance)
+
+@pre_init(sender=ActivityDataset)
+def activity_pre_init(model_class, instance:ActivityDataset):
+    add_field_into_data(model_class, instance)
+
+
+@pre_init(sender=ExchangeDataset)
+def activity_pre_init(model_class, instance:ExchangeDataset):
+    add_field_into_data(model_class, instance)
+
 
 @cache
 def get_id(key):
@@ -44,3 +94,47 @@ def get_id(key):
             ).id
         except DoesNotExist:
             raise UnknownObject
+
+
+def insert_many(items, modelClass:type[Model], drop_meta_data=False):
+    """Generic insert many. Using raw sqlite connection with executemany > super fast"""
+
+    fields = modelClass._meta.sorted_fields
+
+    sql_rows = []
+    for item in items:
+        spread_data_into_fields(modelClass, item)
+        if drop_meta_data :
+            item["data"] = {}
+
+        def to_sql(field):
+            res = field.db_value(item.get(field.name))
+
+            # For some reason, JSON field returns a peewee json "Function"
+            if isinstance(res, Function):
+                res = res.arguments[0]
+            return res
+
+        # Yield single row
+        sql_rows.append(list(to_sql(field) for field in fields))
+
+    # Get raw sqlite connection
+    db = modelClass._meta.database
+    conn = db.connection()
+    cursor = conn.cursor()
+
+    column_names = [f'"{f.column_name}"' for f in fields]
+    placeholders = ", ".join(["?"] * len(fields))
+
+    sql = f"""INSERT INTO {modelClass._meta.table_name} ({", ".join(column_names)}) VALUES ({placeholders})"""
+
+    cursor.executemany(sql, sql_rows)
+
+
+def insert_many_exchanges(exchanges : list[ExchangeDataset], drop_meta_data=False):
+    insert_many(exchanges, ExchangeDataset, drop_meta_data=drop_meta_data)
+
+def insert_many_activities(activities : list[ActivityDataset], drop_meta_data = False):
+    insert_many(activities, ActivityDataset, drop_meta_data=drop_meta_data)
+
+

--- a/bw2data/backends/schema.py
+++ b/bw2data/backends/schema.py
@@ -1,3 +1,5 @@
+from functools import cache
+
 from peewee import DoesNotExist, TextField
 
 from bw2data.errors import UnknownObject
@@ -27,7 +29,7 @@ class ExchangeDataset(SnowflakeIDBaseClass):
     output_database = TextField()  # Canonical
     type = TextField()  # Reset from `data`
 
-
+@cache
 def get_id(key):
     if isinstance(key, int):
         try:

--- a/bw2data/backends/utils.py
+++ b/bw2data/backends/utils.py
@@ -80,7 +80,7 @@ def dict_as_activitydataset(ds: Any, add_snowflake_id: bool = False) -> dict:
     }
     # Use during `insert_many` calls as these skip auto id generation because they don't call
     # `.save()`
-    if add_snowflake_id:
+    if add_snowflake_id and not "id" in val :
         val["id"] = next(snowflake_id_generator)
     return val
 

--- a/bw2data/configuration.py
+++ b/bw2data/configuration.py
@@ -158,7 +158,12 @@ class Config(BaseSettings):
     cache: dict = {}
     metadata: list = []
     sqlite3_databases: list = []
+
+    # If true, drop extra metadata on activities and exchanges upon import (method write())
+    drop_metadata: bool = False
+
     _windows: bool = platform.system() == "Windows"
+
 
     model_config = SettingsConfigDict(
         env_file="brightway-configuration.env",

--- a/bw2data/serialization.py
+++ b/bw2data/serialization.py
@@ -13,21 +13,14 @@ from bw2data.errors import PickleError
 from bw2data.fatomic import open as atomic_open
 from bw2data.utils import maybe_path
 
-try:
-    import anyjson
-except ImportError:
-    anyjson = None
-    import json
+import orjson
 
 
 class JsonWrapper:
     @classmethod
     def dump(self, data, filepath):
         with atomic_open(filepath, "w") as f:
-            if anyjson:
-                f.write(anyjson.serialize(data))
-            else:
-                json.dump(data, f, indent=2)
+            f.write(JsonWrapper.dumps(data))
 
     @classmethod
     def dump_bz2(self, data, filepath):
@@ -37,10 +30,8 @@ class JsonWrapper:
 
     @classmethod
     def load(self, file):
-        if anyjson:
-            return anyjson.deserialize(open(file, encoding="utf-8").read())
-        else:
-            return json.load(open(file, encoding="utf-8"))
+         with open(file, encoding="utf-8") as f:
+            return JsonWrapper.loads(f.read())
 
     @classmethod
     def load_bz2(self, filepath):
@@ -48,17 +39,11 @@ class JsonWrapper:
 
     @classmethod
     def dumps(self, data):
-        if anyjson:
-            return anyjson.serialize(data)
-        else:
-            return json.dumps(data)
+        return orjson.dumps(data, option=orjson.OPT_INDENT_2).decode("utf-8")
 
     @classmethod
     def loads(self, data):
-        if anyjson:
-            return anyjson.deserialize(data)
-        else:
-            return json.loads(data)
+        return orjson.loads(data)
 
 
 class JsonSanitizer:

--- a/bw2data/signals.py
+++ b/bw2data/signals.py
@@ -1,5 +1,5 @@
 from blinker import signal
-from peewee import Model
+from playhouse.signals import Model
 
 try:
     from typing import override

--- a/bw2data/snowflake_ids.py
+++ b/bw2data/snowflake_ids.py
@@ -4,6 +4,7 @@ from peewee import IntegerField
 from snowflake import SnowflakeGenerator
 
 from bw2data.signals import SignaledDataset
+import base64
 
 # Jan 1, 2024
 # from datetime import datetime
@@ -37,3 +38,9 @@ class SnowflakeIDBaseClass(SignaledDataset):
             self.id = next(snowflake_id_generator)
             kwargs["force_insert"] = True
         super().save(**kwargs)
+
+
+def snowflake_to_code(id_int):
+    """Convert unique int id to short string code"""
+    b = id_int.to_bytes((id_int.bit_length() + 7) // 8, 'big')
+    return base64.urlsafe_b64encode(b).decode().rstrip('=')

--- a/bw2data/sqlite.py
+++ b/bw2data/sqlite.py
@@ -1,8 +1,8 @@
-import json
 import pickle
 
-from peewee import BlobField, SqliteDatabase, TextField
-
+from peewee import BlobField, SqliteDatabase, Model
+import playhouse.sqlite_ext as sqlite
+import orjson
 from bw2data.logs import stdout_feedback_logger
 
 
@@ -51,28 +51,90 @@ class SubstitutableDatabase:
         self.execute_sql("VACUUM;")
 
 
-class JSONField(TextField):
-    """Simpler JSON field that doesn't support advanced querying and is human-readable"""
+class FastJSONField(sqlite.JSONField):
+    """Json field using orjson for faster serialization"""
+    def __init__(self, *args, **kwargs):
+        super().__init__(
+            *args,
+            json_loads=FastJSONField._loads,
+            json_dumps=FastJSONField._dumps,
+            **kwargs)
 
-    def db_value(self, value):
-        return super().db_value(
-            json.dumps(
-                value,
-                ensure_ascii=False,
-                indent=2,
-                default=lambda x: x.isoformat() if hasattr(x, "isoformat") else x,
-            )
-        )
+    @classmethod
+    def _loads(cls, value):
+        return orjson.loads(value)
 
-    def python_value(self, value):
-        return json.loads(value)
+    @classmethod
+    def _dumps(cls, value):
+        return orjson.dumps(value).decode("utf-8")
 
 
-class TupleJSONField(JSONField):
-    def python_value(self, value):
-        if value is None:
+class CleanJSONField(FastJSONField):
+    """JSON Field that deletes unwanted fields before saving to DB"""
+
+    def setup_model(self, model_class):
+        """Called after setup of the model because we can't circular reference a class in construction"""
+        self.remove_fields = [f for f in model_class._meta.fields if f not in ['data', "id"]]
+
+        # Add extra mapping from the Meta attribute of the model
+        self.remove_fields.extend(list(model_class._meta.extra_data_mapping.keys()))
+
+
+    def db_value(self, dic):
+        if dic is None:
             return None
-        data = json.loads(value)
-        if isinstance(data, list):
-            data = tuple(data)
-        return data
+        cleaned = dic.copy()
+        for field in self.remove_fields:
+            cleaned.pop(field, None)
+        return super().db_value(cleaned)
+
+
+def spread_data_into_fields(model_class:type[Model], instance):
+    """Called before save to DB, to put the fields of 'data' into proper fields."""
+
+    if isinstance(instance, Model):
+        # This should accomodate instance being either a Dataset instance of a dict (as called by insert_many)
+        instance = instance.__data__
+
+    data = instance["data"]
+
+    if not data:
+        return
+    for key, value in data.items():
+        if key in model_class._meta.fields:
+            instance[key] = value
+
+    # Process extra mapping
+    for data_key, attr in model_class._meta.extra_data_mapping.items():
+        val = data.get(data_key)
+        if val is not None:
+            if isinstance(attr, tuple):
+                for key, val in zip(attr, val):
+                    instance[key] = val
+            else:
+                instance[attr] = val
+
+
+def add_field_into_data(model_class, instance):
+    """Called after load from DB to put back  attributes of Peewee Dataset into data """
+    if not instance.data:
+        instance.data = {}
+    for key in model_class._meta.fields:
+        if key in  ["data", "id"]:
+            continue
+        val = getattr(instance, key)
+        if val is not None:
+            instance.data[key] = getattr(instance, key)
+
+    # Process extra mapping
+    for data_key, attr in model_class._meta.extra_data_mapping.items():
+        if isinstance(attr, tuple):
+            val = tuple(getattr(instance, key) for key in attr)
+        else:
+            val = getattr(instance, attr)
+        instance.data[data_key] = val
+
+
+
+
+

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,6 +50,7 @@ dependencies = [
     "typing_extensions",
     "voluptuous",
     "wrapt",
+    "orjson"
 ]
 
 [project.urls]


### PR DESCRIPTION
This pull request is an attempt to improve the performances of the backend `lci` db :
- ⚡ Reduce **import time** : from **6 min** to **1.3 min**
- 🗃 Reduce **size on disk** : from **1.2 Gb** to **250 Mb** (dropping some extra metadata)

I just packaged and published it [on pypi](https://pypi.org/project/bw2data-perf/4.5.4/). You can uninstall **bw2data** and install this version instead to give it a try. 

I would be happy to have your feedbacks.

# Main changes

The following changes have been made :

## From `Pickle` to `JSON`

Changed `data` column from **Pickle** to **JSON field**.

The use of `pickle` makes it impossible to query with SQL and prone to backward incompatibilities (change with python version).

Instead, SQLite has a great [native support for JSON](https://sqlite.org/json1.html).

## Added columns to `Activity` and `Exchange` tables

Add all useful columns to activity & exchange tables:

Regular operations used to fetch the whole bundled `data` blob and extract relevant information from here. 
This was not efficient, especially for `process()`.

Instead, all useful information is spread into new columns and removed from data upon save, and added again into data upon load. 
This ensures maximal backward compatibility with existing code.  

## Deactivated some checks on import

Some checks were not necessary and taking time upon bulk import :
- Deactivate typo check on import by default
- Don't do "vaccum" if database was empty before write()

## Added an option to drop extra meta data

An option `drop_metadata` has been added to `bw2data.config`. 

If activated, extra metadata will be dropped upon import, saving disk space (from 1.2 Gb to 280Mb) while having everything work fine.

We could make this option more precise and provide a list of metadata fields to keep.


## Improved import performance

Use raw SQLite queries for many inserts, using [executemany()](https://docs.python.org/3/library/sqlite3.html#sqlite3.Cursor.executemany) : much faster than using Peewee.

# 📊 Results 

Here are the results for a typical import of **ecoinvent 3.9** :

| Method                 | Import Time (min) | process() Time (s) | Size (GB) |
|------------------------|-------------------|--------------------|-----------|
| bw2data-legacy         | 6.0               | 27                 | 1.20      |
| bw2data-perf           | 1.3               | 7                  | 1.00      |
| bw2data-perf+drop_meta | 1.3               | 7                  | 0.28      |


Results for typical import of ecoinvent 3.9 :
- Total import time goes from 6 minutes to 1m30s
- process() does from  25s to 7s
- Size of lci/databases.db goes from 1.2 Gb to 260 Mb (dropping extra metadata) or 1.0 Gb (keeping all extra meta data)

# 🔃 Compatibility

Those changes should be transparent for other packages : the content of `data` is the same after load from database.

I've tried :
- The test suite of `lca_algebraic` : ✅ Ok
- `Activity browser`: LCI computation + monta carlo + Sanke work fine but some columns are empty (categories, ...) in the UI.
  I saw that the code in `AB` does [some nasty stuff](https://github.com/LCA-ActivityBrowser/activity-browser/blob/Dev/activity_browser/bwutils/superstructure/activities.py#L56), by accessing directly to the SQlite DB rather than relying on the bw2data abstraction. 

# ⌛ TODO

## Automatic migration 

The SQlite db doesn't contain `user_version` yet. 

This could be useful to keep track the evolution of the database, fail if trying to open a database with different versions, 
and even propose automatic migration.

## Integrate full text search tables into lci database

I find it weird that data are spread into many files of many different formats (Sqlite, NPY, pickle). 
Ideally, most information should fit into a single homogeneous database.

Now that relevant information is stored into separate columns, we could even spare an additional 60Mb of space, by having FTS into lci database and using the [external content feature](https://sqlite.org/fts5.html#external_content_tables)
 
## Compress *migrations* folder

The migration folder takes **160Mb**, gzipping the json files would reduce it to only **5Mb** !


