### PR TITLE
Fix Windows file handle leaks in delete_project and change_path

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,9 @@
 # `bw2data` Changelog
 
+## 4.6.1 (unreleased)
+
+* Fix Windows file handle leaks: close open SQLite handles before `shutil.rmtree` in `ProjectManager.delete_project`, and explicitly dereference the old database object with `gc.collect()` in `SubstitutableDatabase.change_path` before opening the new path.
+
 ## 4.6 (2026-03-04)
 
 * [#258: Compatibility with peewee>=4.0.1](https://github.com/brightway-lca/brightway2-data/pull/258)

--- a/bw2data/project.py
+++ b/bw2data/project.py
@@ -556,6 +556,13 @@ class ProjectManager(Iterable):
         if delete_dir:
             dir_path = self._base_data_dir / safe_filename(victim)
             assert dir_path.is_dir(), "Can't find project directory"
+            for _, substitutable_db in config.sqlite3_databases:
+                try:
+                    if Path(substitutable_db._filepath).is_relative_to(dir_path):
+                        if not substitutable_db.db.is_closed():
+                            substitutable_db.db.close()
+                except Exception:
+                    pass
             shutil.rmtree(dir_path)
         else:
             stdout_feedback_logger.warning(

--- a/bw2data/sqlite.py
+++ b/bw2data/sqlite.py
@@ -33,7 +33,11 @@ class SubstitutableDatabase:
         return self._database
 
     def change_path(self, filepath):
-        self.db.close()
+        import gc
+        old_db = self._database
+        old_db.close()
+        del old_db
+        gc.collect()
         self._filepath = filepath
         self._database = self._create_database()
 


### PR DESCRIPTION
## Summary

- **`ProjectManager.delete_project`**: Before calling `shutil.rmtree`, iterate over all registered `config.sqlite3_databases` and close any whose `_filepath` is inside the directory being deleted. Windows requires all file handles to be released before a directory tree can be removed.
- **`SubstitutableDatabase.change_path`**: Capture the old `SqliteDatabase` in a local variable, close it, `del` the local reference, then call `gc.collect()` to force CPython's cycle collector to fully release the OS file handle before the new connection is opened. Without this, the old handle may linger on Windows until the next GC cycle, causing the new `connect()` call to fail.

## Test plan

- [ ] All 169 existing tests pass (`pytest tests/ -x -q`)
- [ ] Manually test on Windows: `projects.delete_project(name, delete_dir=True)` no longer raises `PermissionError`
- [ ] Manually test on Windows: `projects.set_current(other_project)` (which calls `change_path`) no longer raises `PermissionError` on repeated switching