### PR TITLE
Reduce CI matrix to Python 3.9, 3.11, and 3.14

### DIFF
--- a/.github/workflows/python-test.yml
+++ b/.github/workflows/python-test.yml
@@ -32,7 +32,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        py-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
+        py-version: ["3.9", "3.11", "3.14"]
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
## Summary

- Removes Python 3.10, 3.12, and 3.13 from the test matrix
- Keeps oldest supported (3.9), current stable (3.11), and upcoming (3.14)
- Applies to all three OS targets (ubuntu, windows, macos)

## Test plan

- [ ] Verify CI runs on the three specified Python versions
- [ ] Confirm no test failures introduced by the version change