### PR TITLE
Release 4.6.2

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,9 @@
 # `bw2data` Changelog
 
+## 4.6.2 (2026-04-15)
+
+* Version bump; 4.6.1 was not published to PyPI
+
 ## 4.6.1 (2026-04-15)
 
 * [#259: Fix Windows file handle leaks in `delete_project` and `change_path`](https://github.com/brightway-lca/brightway2-data/pull/259)

--- a/README.md
+++ b/README.md
@@ -37,6 +37,16 @@ $ pip install bw2data
 Contributions are very welcome.
 To learn more, see the [Contributor Guide][Contributor Guide].
 
+## Releasing a new version
+
+1. Create a release branch: `git checkout -b release/X.Y.Z`
+2. Update `__version__` in `bw2data/__init__.py`
+3. Update `CHANGES.md` with the release date and links to merged PRs
+4. Commit, push the branch, and open a PR
+5. Push the tag to trigger PyPI publication: `git tag X.Y.Z && git push origin X.Y.Z`
+
+The tag push triggers the GitHub Actions deploy workflow, which builds and publishes the package to PyPI using trusted publishing.
+
 ## License
 
 Distributed under the terms of the [BSD 3 Clause license][License],

--- a/bw2data/__init__.py
+++ b/bw2data/__init__.py
@@ -33,7 +33,7 @@ __all__ = [
     "weightings",
 ]
 
-__version__ = "4.6.1"
+__version__ = "4.6.2"
 
 from bw2data.configuration import config, labels
 from bw2data.project import projects


### PR DESCRIPTION
## Summary

- Bump version to 4.6.2
- 4.6.1 was merged to `main` but the tag was never pushed, so it was not published to PyPI

## After merging

Push the tag to trigger the PyPI deploy workflow:
```
git tag 4.6.2 && git push --tags
```