### PR TITLE
feat: write database_dependencies to datapackage metadata (v4.7)

### DIFF
--- a/bw2data/__init__.py
+++ b/bw2data/__init__.py
@@ -33,7 +33,7 @@ __all__ = [
     "weightings",
 ]
 
-__version__ = "4.6.2"
+__version__ = "4.7"
 
 from bw2data.configuration import config, labels
 from bw2data.project import projects

--- a/bw2data/backends/base.py
+++ b/bw2data/backends/base.py
@@ -1103,6 +1103,7 @@ Here are the type values usually used for nodes:
                 name=clean_datapackage_name(self.name + " activity metadata"),
             )
 
+        dp.metadata["database_dependencies"] = sorted(dependents)
         dp.finalize_serialization()
 
         self.metadata["depends"] = sorted(dependents)

--- a/bw2data/updates.py
+++ b/bw2data/updates.py
@@ -120,6 +120,11 @@ class Updates:
             "automatic": True,
             "explanation": "bw2data 4.0 release switched to a new database search implementation",
         },
+        "4.7 database dependencies in datapackage": {
+            "method": "expire_all_processed_data_47",
+            "automatic": True,
+            "explanation": "bw2data 4.7 adds database_dependencies to datapackage metadata; all databases must be reprocessed",
+        },
     }
 
     @classmethod
@@ -224,6 +229,10 @@ class Updates:
 
     @classmethod
     def expire_all_processed_data_40(cls):
+        cls._reprocess_all()
+
+    @classmethod
+    def expire_all_processed_data_47(cls):
         cls._reprocess_all()
 
     @classmethod

--- a/tests/database.py
+++ b/tests/database.py
@@ -506,6 +506,63 @@ def test_processed_array():
 
 
 @bw2test
+def test_process_writes_database_dependencies_to_datapackage():
+    Database("other database").write(
+        {
+            ("other database", "x"): {
+                "type": "process",
+                "exchanges": [
+                    {"input": ("other database", "x"), "amount": 1, "type": "production"}
+                ],
+            }
+        }
+    )
+    db_a = Database("a database")
+    db_a.write(
+        {
+            ("a database", "1"): {
+                "type": "process",
+                "exchanges": [
+                    {
+                        "input": ("a database", "1"),
+                        "amount": 1,
+                        "type": "production",
+                    },
+                    {
+                        "input": ("other database", "x"),
+                        "amount": 0.5,
+                        "type": "technosphere",
+                    },
+                ],
+            }
+        }
+    )
+    package = db_a.datapackage()
+    assert package.metadata["database_dependencies"] == ["other database"]
+
+
+@bw2test
+def test_process_writes_empty_database_dependencies_when_no_external_inputs():
+    db = Database("a database")
+    db.write(
+        {
+            ("a database", "1"): {
+                "type": "process",
+                "exchanges": [
+                    {
+                        "input": ("a database", "1"),
+                        "amount": 1,
+                        "type": "production",
+                    }
+                ],
+            }
+        }
+    )
+    package = db.datapackage()
+    assert package.metadata["database_dependencies"] == []
+
+
+@bw2test
 def test_processed_array_with_metadata():
     database = Database("a database")
     database.write(


### PR DESCRIPTION
## Summary

- `Database.process()` now writes `dp.metadata["database_dependencies"] = sorted(dependents)` into the datapackage before `finalize_serialization()`, so downstream consumers can inspect which databases a datapackage depends on without re-scanning exchanges
- The `dependents` set is already computed during exchange iteration — this change only surfaces it into the datapackage file (the existing `self.metadata["depends"]` entry is unchanged)
- New automatic migration `"4.7 database dependencies in datapackage"` reprocesses all databases so existing datapackages gain the new field
- Version bumped to `4.7`

## Test plan

- [ ] `test_process_writes_database_dependencies_to_datapackage` — writes two databases with a cross-database technosphere exchange and asserts `package.metadata["database_dependencies"] == ["other database"]`
- [ ] `test_process_writes_empty_database_dependencies_when_no_external_inputs` — self-contained database asserts `package.metadata["database_dependencies"] == []`