### PR TITLE
Add memoization cache to get_id() with signal-based invalidation

### DIFF
--- a/bw2data/backends/schema.py
+++ b/bw2data/backends/schema.py
@@ -1,3 +1,5 @@
+from functools import cache
+
 from peewee import DoesNotExist, TextField
 
 from bw2data.errors import UnknownObject
@@ -27,7 +29,7 @@ class ExchangeDataset(SnowflakeIDBaseClass):
     output_database = TextField()  # Canonical
     type = TextField()  # Reset from `data`
 
-
+@cache
 def get_id(key):
     if isinstance(key, int):
         try:

--- a/bw2data/backends/schema.py
+++ b/bw2data/backends/schema.py
@@ -1,8 +1,15 @@
-from functools import cache
-
 from peewee import DoesNotExist, TextField
 
 from bw2data.errors import UnknownObject
+from bw2data.signals import (
+    on_activity_code_change,
+    on_activity_database_change,
+    on_database_delete,
+    on_database_reset,
+    on_database_write,
+    project_changed,
+    signaleddataset_on_delete,
+)
 from bw2data.snowflake_ids import SnowflakeIDBaseClass
 from bw2data.sqlite import PickleField
 
@@ -29,7 +36,10 @@ class ExchangeDataset(SnowflakeIDBaseClass):
     output_database = TextField()  # Canonical
     type = TextField()  # Reset from `data`
 
-@cache
+
+_get_id_cache: dict = {}
+
+
 def get_id(key):
     if isinstance(key, int):
         try:
@@ -38,9 +48,43 @@ def get_id(key):
             raise UnknownObject
         return key
     else:
+        cache_key = (key[0], key[1])
+        if cache_key in _get_id_cache:
+            return _get_id_cache[cache_key]
         try:
-            return ActivityDataset.get(
+            result = ActivityDataset.get(
                 ActivityDataset.database == key[0], ActivityDataset.code == key[1]
             ).id
+            _get_id_cache[cache_key] = result
+            return result
         except DoesNotExist:
             raise UnknownObject
+
+
+def _clear_get_id_cache(sender, **kwargs):
+    _get_id_cache.clear()
+
+
+def _remove_database_from_get_id_cache(sender, name: str, **kwargs):
+    for k in [k for k in _get_id_cache if k[0] == name]:
+        del _get_id_cache[k]
+
+
+def _remove_activity_from_get_id_cache(sender, old=None, **kwargs):
+    if isinstance(old, ActivityDataset):
+        _get_id_cache.pop((old.database, old.code), None)
+
+
+def _remove_changed_activity_key_from_get_id_cache(sender, old=None, **kwargs):
+    if old is not None:
+        for k in [k for k, v in _get_id_cache.items() if v == old["id"]]:
+            del _get_id_cache[k]
+
+
+project_changed.connect(_clear_get_id_cache)
+on_database_delete.connect(_remove_database_from_get_id_cache)
+on_database_reset.connect(_remove_database_from_get_id_cache)
+on_database_write.connect(_remove_database_from_get_id_cache)
+signaleddataset_on_delete.connect(_remove_activity_from_get_id_cache)
+on_activity_database_change.connect(_remove_changed_activity_key_from_get_id_cache)
+on_activity_code_change.connect(_remove_changed_activity_key_from_get_id_cache)

--- a/tests/test_get_id_cache.py
+++ b/tests/test_get_id_cache.py
@@ -1,0 +1,133 @@
+from bw2data import databases, get_id, projects
+from bw2data.backends.schema import _get_id_cache
+from bw2data.database import Database
+from bw2data.tests import bw2test
+
+
+def _write_db(name="db", data=None):
+    db = Database(name)
+    db.write(data or {(name, "a"): {}, (name, "b"): {}})
+    return db
+
+
+@bw2test
+def test_get_id_cache_populates():
+    _write_db()
+    get_id(("db", "a"))
+    assert ("db", "a") in _get_id_cache
+
+
+@bw2test
+def test_get_id_cache_returns_same_value():
+    _write_db()
+    first = get_id(("db", "a"))
+    second = get_id(("db", "a"))
+    assert first == second
+
+
+@bw2test
+def test_get_id_cache_project_changed():
+    _write_db()
+    get_id(("db", "a"))
+    assert ("db", "a") in _get_id_cache
+
+    projects.set_current("another project")
+
+    assert len(_get_id_cache) == 0
+
+
+@bw2test
+def test_get_id_cache_database_delete():
+    _write_db("foo")
+    _write_db("bar")
+    get_id(("foo", "a"))
+    get_id(("bar", "a"))
+    assert ("foo", "a") in _get_id_cache
+    assert ("bar", "a") in _get_id_cache
+
+    del databases["foo"]
+
+    assert ("foo", "a") not in _get_id_cache
+    assert ("bar", "a") in _get_id_cache
+
+
+@bw2test
+def test_get_id_cache_database_reset():
+    _write_db("foo")
+    _write_db("bar")
+    get_id(("foo", "a"))
+    get_id(("bar", "a"))
+    assert ("foo", "a") in _get_id_cache
+    assert ("bar", "a") in _get_id_cache
+
+    Database("foo").delete(warn=False)
+
+    assert ("foo", "a") not in _get_id_cache
+    assert ("bar", "a") in _get_id_cache
+
+
+@bw2test
+def test_get_id_cache_database_write():
+    _write_db("foo")
+    _write_db("bar")
+    get_id(("foo", "a"))
+    get_id(("bar", "a"))
+    assert ("foo", "a") in _get_id_cache
+    assert ("bar", "a") in _get_id_cache
+
+    Database("foo").write({("foo", "x"): {}})
+
+    assert ("foo", "a") not in _get_id_cache
+    assert ("bar", "a") in _get_id_cache
+
+
+@bw2test
+def test_get_id_cache_activity_delete():
+    _write_db("foo")
+    _write_db("bar")
+    get_id(("foo", "a"))
+    get_id(("foo", "b"))
+    get_id(("bar", "a"))
+    assert ("foo", "a") in _get_id_cache
+    assert ("foo", "b") in _get_id_cache
+    assert ("bar", "a") in _get_id_cache
+
+    Database("foo").get("a").delete()
+
+    assert ("foo", "a") not in _get_id_cache
+    assert ("foo", "b") in _get_id_cache
+    assert ("bar", "a") in _get_id_cache
+
+
+@bw2test
+def test_get_id_cache_activity_code_change():
+    _write_db("foo")
+    _write_db("bar")
+    get_id(("foo", "a"))
+    get_id(("foo", "b"))
+    get_id(("bar", "a"))
+    assert ("foo", "a") in _get_id_cache
+
+    act = Database("foo").get("a")
+    act["code"] = "new_code"
+
+    assert ("foo", "a") not in _get_id_cache
+    assert ("foo", "b") in _get_id_cache
+    assert ("bar", "a") in _get_id_cache
+
+
+@bw2test
+def test_get_id_cache_activity_database_change():
+    _write_db("foo")
+    _write_db("bar")
+    get_id(("foo", "a"))
+    get_id(("foo", "b"))
+    get_id(("bar", "a"))
+    assert ("foo", "a") in _get_id_cache
+
+    act = Database("foo").get("a")
+    act["database"] = "bar"
+
+    assert ("foo", "a") not in _get_id_cache
+    assert ("foo", "b") in _get_id_cache
+    assert ("bar", "a") in _get_id_cache


### PR DESCRIPTION
## Summary

- Adds a module-level dict cache to `get_id()` for `(database, code) → id` lookups, avoiding repeated SQLite queries during large imports (reported to save ~1 minute on ecoinvent imports in #254)
- Cache is invalidated via blinker signal handlers on all relevant events: project switch, database delete/reset/write, individual activity deletion, and activity code or database changes
- Chose a plain dict over `functools.lru_cache` because selective per-database and per-activity invalidation requires `__delitem__`, which `lru_cache` does not expose

## Test plan

- [ ] `test_get_id_cache_populates` — cache is written on first call
- [ ] `test_get_id_cache_returns_same_value` — cache hit returns correct value
- [ ] `test_get_id_cache_project_changed` — `project_changed` clears entire cache
- [ ] `test_get_id_cache_database_delete` — `on_database_delete` removes only that database's entries
- [ ] `test_get_id_cache_database_reset` — `on_database_reset` removes only that database's entries
- [ ] `test_get_id_cache_database_write` — `on_database_write` removes only that database's entries
- [ ] `test_get_id_cache_activity_delete` — `signaleddataset_on_delete` removes only that activity's entry
- [ ] `test_get_id_cache_activity_code_change` — `on_activity_code_change` removes old key, leaves others
- [ ] `test_get_id_cache_activity_database_change` — `on_activity_database_change` removes old key, leaves others

Closes #254