### PR TITLE
Release 4.7

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,7 @@
 
 * [#265: Write `database_dependencies` to datapackage metadata](https://github.com/brightway-lca/brightway2-data/pull/265)
 * [#266: Add memoization cache to `get_id()` with signal-based invalidation](https://github.com/brightway-lca/brightway2-data/pull/266)
+* [#268: Use raw SQLite `executemany` for bulk database writes](https://github.com/brightway-lca/brightway2-data/pull/268)
 
 ## 4.6.2 (2026-04-15)
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,6 +5,7 @@
 * [#265: Write `database_dependencies` to datapackage metadata](https://github.com/brightway-lca/brightway2-data/pull/265)
 * [#266: Add memoization cache to `get_id()` with signal-based invalidation](https://github.com/brightway-lca/brightway2-data/pull/266)
 * [#268: Use raw SQLite `executemany` for bulk database writes](https://github.com/brightway-lca/brightway2-data/pull/268)
+* [#270: Fix unclosed sqlite3 connections in `updates.py`](https://github.com/brightway-lca/brightway2-data/pull/270)
 
 ## 4.6.2 (2026-04-15)
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,10 @@
 # `bw2data` Changelog
 
+## 4.7 (2026-05-13)
+
+* [#265: Write `database_dependencies` to datapackage metadata](https://github.com/brightway-lca/brightway2-data/pull/265)
+* [#266: Add memoization cache to `get_id()` with signal-based invalidation](https://github.com/brightway-lca/brightway2-data/pull/266)
+
 ## 4.6.2 (2026-04-15)
 
 * Version bump; 4.6.1 was not published to PyPI


### PR DESCRIPTION
## Summary

- [#265: Write `database_dependencies` to datapackage metadata](https://github.com/brightway-lca/brightway2-data/pull/265) — `Database.process()` now writes `dp.metadata["database_dependencies"]` into the datapackage so downstream consumers can inspect cross-database dependencies without re-scanning exchanges; includes an automatic migration that reprocesses all existing databases
- [#266: Add memoization cache to `get_id()` with signal-based invalidation](https://github.com/brightway-lca/brightway2-data/pull/266) — avoids repeated SQLite lookups during large imports (saves ~1 minute on ecoinvent imports); cache is selectively invalidated via blinker signals on project switch, database delete/reset/write, and activity changes
- [#268: Use raw SQLite `executemany` for bulk database writes](https://github.com/brightway-lca/brightway2-data/pull/268) — bypasses Peewee ORM overhead during `Database.write()`, removing the old 125-row batch flush limit and significantly speeding up large database imports
- [#270: Fix unclosed sqlite3 connections in updates.py](https://github.com/brightway-lca/brightway2-data/pull/270) — replaced bare `sqlite3.connect()` calls with Peewee-managed connections or `contextlib.closing()` to prevent `ResourceWarning: unclosed database` across tests

## Test plan

- [ ] CI passes
- [ ] Check PyPI release after merge