### PR TITLE
Use raw SQLite executemany for bulk database writes

### DIFF
--- a/bw2data/backends/base.py
+++ b/bw2data/backends/base.py
@@ -18,7 +18,13 @@ from tqdm import tqdm
 from bw2data import calculation_setups, config, databases, geomapping
 from bw2data.backends import sqlite3_lci_db
 from bw2data.backends.proxies import Activity
-from bw2data.backends.schema import ActivityDataset, ExchangeDataset, get_id
+from bw2data.backends.schema import (
+    ActivityDataset,
+    ExchangeDataset,
+    get_id,
+    insert_many_activities,
+    insert_many_exchanges,
+)
 from bw2data.backends.typos import (
     check_activity_keys,
     check_activity_type,
@@ -601,7 +607,7 @@ class SQLiteBackend(ProcessedDataStore):
         exchanges: list,
         activities: list,
         check_typos: bool = True,
-    ) -> (list, list):
+    ) -> None:
         for exchange in ds.get("exchanges", []):
             if "input" not in exchange or "amount" not in exchange:
                 raise InvalidExchange
@@ -616,15 +622,6 @@ class SQLiteBackend(ProcessedDataStore):
                 exchange["output"] = (ds["database"], ds["code"])
             exchanges.append(dict_as_exchangedataset(exchange))
 
-            # Query gets passed as INSERT INTO x VALUES ('?', '?'...)
-            # SQLite3 has a limit of 999 variables,
-            # So 6 fields * 125 is under the limit
-            # Otherwise get the following:
-            # peewee.OperationalError: too many SQL variables
-            if len(exchanges) > 125:
-                ExchangeDataset.insert_many(exchanges).execute()
-                exchanges = []
-
         ds = {k: v for k, v in ds.items() if k != "exchanges"}
 
         if check_typos:
@@ -632,12 +629,6 @@ class SQLiteBackend(ProcessedDataStore):
             check_activity_keys(ds)
 
         activities.append(dict_as_activitydataset(ds, add_snowflake_id=True))
-
-        if len(activities) > 125:
-            ActivityDataset.insert_many(activities).execute()
-            activities = []
-
-        return exchanges, activities
 
     def _efficient_write_many_data(
         self, data: list, indices: bool = True, check_typos: bool = True
@@ -652,14 +643,10 @@ class SQLiteBackend(ProcessedDataStore):
             exchanges, activities = [], []
 
             for ds in tqdm_wrapper(data, getattr(config, "is_test", False)):
-                exchanges, activities = self._efficient_write_dataset(
-                    ds, exchanges, activities, check_typos
-                )
+                self._efficient_write_dataset(ds, exchanges, activities, check_typos)
 
-            if activities:
-                ActivityDataset.insert_many(activities).execute()
-            if exchanges:
-                ExchangeDataset.insert_many(exchanges).execute()
+            insert_many_activities(activities)
+            insert_many_exchanges(exchanges)
             sqlite3_lci_db.db.commit()
             sqlite3_lci_db.vacuum()
         except:

--- a/bw2data/backends/base.py
+++ b/bw2data/backends/base.py
@@ -21,9 +21,9 @@ from bw2data.backends.proxies import Activity
 from bw2data.backends.schema import (
     ActivityDataset,
     ExchangeDataset,
+    _insert_many_activities,
+    _insert_many_exchanges,
     get_id,
-    insert_many_activities,
-    insert_many_exchanges,
 )
 from bw2data.backends.typos import (
     check_activity_keys,
@@ -645,8 +645,8 @@ class SQLiteBackend(ProcessedDataStore):
             for ds in tqdm_wrapper(data, getattr(config, "is_test", False)):
                 self._efficient_write_dataset(ds, exchanges, activities, check_typos)
 
-            insert_many_activities(activities)
-            insert_many_exchanges(exchanges)
+            _insert_many_activities(activities)
+            _insert_many_exchanges(exchanges)
             sqlite3_lci_db.db.commit()
             sqlite3_lci_db.vacuum()
         except:

--- a/bw2data/backends/schema.py
+++ b/bw2data/backends/schema.py
@@ -1,3 +1,5 @@
+import pickle
+
 from peewee import DoesNotExist, TextField
 
 from bw2data.errors import UnknownObject
@@ -88,3 +90,53 @@ on_database_write.connect(_remove_database_from_get_id_cache)
 signaleddataset_on_delete.connect(_remove_activity_from_get_id_cache)
 on_activity_database_change.connect(_remove_changed_activity_key_from_get_id_cache)
 on_activity_code_change.connect(_remove_changed_activity_key_from_get_id_cache)
+
+
+def insert_many_activities(activities: list) -> None:
+    """Bulk-insert activity dicts via raw SQLite executemany, bypassing Peewee ORM overhead.
+
+    Each dict must be in the format produced by dict_as_activitydataset(ds, add_snowflake_id=True).
+    """
+    if not activities:
+        return
+    conn = ActivityDataset._meta.database.connection()
+    conn.cursor().executemany(
+        'INSERT INTO "activitydataset" ("id", "data", "code", "database", "location", "name", "product", "type") VALUES (?, ?, ?, ?, ?, ?, ?, ?)',
+        [
+            (
+                row["id"],
+                pickle.dumps(row["data"], protocol=4),
+                row["code"],
+                row["database"],
+                row.get("location"),
+                row.get("name"),
+                row.get("product"),
+                row.get("type"),
+            )
+            for row in activities
+        ],
+    )
+
+
+def insert_many_exchanges(exchanges: list) -> None:
+    """Bulk-insert exchange dicts via raw SQLite executemany, bypassing Peewee ORM overhead.
+
+    Each dict must be in the format produced by dict_as_exchangedataset(exc).
+    """
+    if not exchanges:
+        return
+    conn = ExchangeDataset._meta.database.connection()
+    conn.cursor().executemany(
+        'INSERT INTO "exchangedataset" ("data", "input_code", "input_database", "output_code", "output_database", "type") VALUES (?, ?, ?, ?, ?, ?)',
+        [
+            (
+                pickle.dumps(row["data"], protocol=4),
+                row["input_code"],
+                row["input_database"],
+                row["output_code"],
+                row["output_database"],
+                row["type"],
+            )
+            for row in exchanges
+        ],
+    )

--- a/bw2data/backends/schema.py
+++ b/bw2data/backends/schema.py
@@ -110,7 +110,7 @@ def _insert_many_activities(activities: list) -> None:
                 pickle.dumps(row["data"], protocol=4),
                 row["code"],
                 row["database"],
-                row.get("location"),
+                str(v) if (v := row.get("location")) is not None else None,
                 row.get("name"),
                 row.get("product"),
                 row.get("type"),

--- a/bw2data/backends/schema.py
+++ b/bw2data/backends/schema.py
@@ -92,10 +92,11 @@ on_activity_database_change.connect(_remove_changed_activity_key_from_get_id_cac
 on_activity_code_change.connect(_remove_changed_activity_key_from_get_id_cache)
 
 
-def insert_many_activities(activities: list) -> None:
+def _insert_many_activities(activities: list) -> None:
     """Bulk-insert activity dicts via raw SQLite executemany, bypassing Peewee ORM overhead.
 
-    Each dict must be in the format produced by dict_as_activitydataset(ds, add_snowflake_id=True).
+    Must be called within an active transaction. Each dict must be in the format
+    produced by dict_as_activitydataset(ds, add_snowflake_id=True).
     """
     if not activities:
         return
@@ -105,6 +106,7 @@ def insert_many_activities(activities: list) -> None:
         [
             (
                 row["id"],
+                # Protocol 4 matches PickleField.db_value() so both write paths produce identical blobs.
                 pickle.dumps(row["data"], protocol=4),
                 row["code"],
                 row["database"],
@@ -118,10 +120,11 @@ def insert_many_activities(activities: list) -> None:
     )
 
 
-def insert_many_exchanges(exchanges: list) -> None:
+def _insert_many_exchanges(exchanges: list) -> None:
     """Bulk-insert exchange dicts via raw SQLite executemany, bypassing Peewee ORM overhead.
 
-    Each dict must be in the format produced by dict_as_exchangedataset(exc).
+    Must be called within an active transaction. Each dict must be in the format
+    produced by dict_as_exchangedataset(exc).
     """
     if not exchanges:
         return
@@ -130,6 +133,7 @@ def insert_many_exchanges(exchanges: list) -> None:
         'INSERT INTO "exchangedataset" ("data", "input_code", "input_database", "output_code", "output_database", "type") VALUES (?, ?, ?, ?, ?, ?)',
         [
             (
+                # Protocol 4 matches PickleField.db_value() so both write paths produce identical blobs.
                 pickle.dumps(row["data"], protocol=4),
                 row["input_code"],
                 row["input_database"],


### PR DESCRIPTION
## Summary

Extracted from [#255](https://github.com/brightway-lca/brightway2-data/pull/255) by Raphael Jolivet — isolating just the `executemany` bulk-insert optimization without the schema normalization, pickle→JSON, or `drop_metadata` changes from that PR.

- Adds `insert_many_activities()` and `insert_many_exchanges()` to `schema.py`, each using `cursor.executemany()` on the raw SQLite connection to bypass Peewee ORM overhead per row
- `_efficient_write_dataset()` no longer flushes batches of 125 mid-loop (that limit existed because Peewee's `insert_many` builds one large `INSERT ... VALUES (?, ?...), (?, ?...)` statement that hits SQLite's 999-variable limit; `executemany` uses a single prepared statement executed repeatedly, so no such limit applies)
- `_efficient_write_many_data()` collects all datasets in one pass, then calls the two new functions once

Co-authored-by: Raphael Jolivet <contact@raphael-jolivet.name>

## Test plan

- [ ] All 178 existing tests pass
- [ ] Manual benchmark against ecoinvent import to verify speedup