### PR TITLE
Fix as_uncertainty_dict to set loc for deterministic uncertainty types

### DIFF
--- a/bw2data/utils.py
+++ b/bw2data/utils.py
@@ -1,5 +1,6 @@
 import collections
 import itertools
+import math
 import numbers
 import os
 import random
@@ -107,7 +108,17 @@ def clean_exchanges(data):
     return {key: tupleize(value) for key, value in data.items()}
 
 
-POSITIVE_DISTRIBUTIONS = {2, 6, 8, 9, 10}
+POSITIVE_DISTRIBUTIONS = {
+    sa.LognormalUncertainty.id,
+    sa.BernoulliUncertainty.id,
+    sa.WeibullUncertainty.id,
+    sa.GammaUncertainty.id,
+    sa.BetaUncertainty.id,
+}
+NO_UNCERTAINTY_TYPES = {
+    sa.UndefinedUncertainty.id,
+    sa.NoUncertainty.id,
+}
 
 
 def as_uncertainty_dict(value):
@@ -122,6 +133,17 @@ def as_uncertainty_dict(value):
             and "negative" not in value
         ):
             value["negative"] = True
+        uncertainty_type = value.get("uncertainty_type", value.get("uncertainty type"))
+        if uncertainty_type in NO_UNCERTAINTY_TYPES:
+            amount = value.get("amount", 0)
+            loc = value.get("loc")
+            if loc is None or (isinstance(loc, float) and math.isnan(loc)):
+                value["loc"] = amount
+            elif loc != amount:
+                warnings.warn(
+                    f"Uncertainty dict has loc ({loc}) != amount ({amount}) for a no-uncertainty "
+                    f"type ({uncertainty_type}); keeping loc as-is"
+                )
         return value
     try:
         return {"amount": float(value)}

--- a/bw2data/utils.py
+++ b/bw2data/utils.py
@@ -142,7 +142,8 @@ def as_uncertainty_dict(value):
             elif loc != amount:
                 warnings.warn(
                     f"Uncertainty dict has loc ({loc}) != amount ({amount}) for a no-uncertainty "
-                    f"type ({uncertainty_type}); keeping loc as-is"
+                    f"type ({uncertainty_type}); keeping loc as-is, but Monte Carlo average "
+                    f"results will differ from static results"
                 )
         return value
     try:

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -205,6 +205,32 @@ def test_as_uncertainty_dict_set_negative():
     assert as_uncertainty_dict(given) == expected
 
 
+def test_as_uncertainty_dict_loc_nan_set_to_amount():
+    import math
+
+    for uncertainty_type in (0, 1):
+        given = {"uncertainty_type": uncertainty_type, "amount": 42.0, "loc": float("nan")}
+        result = as_uncertainty_dict(given)
+        assert result["loc"] == 42.0
+
+        given = {"uncertainty_type": uncertainty_type, "amount": 42.0}
+        result = as_uncertainty_dict(given)
+        assert result["loc"] == 42.0
+
+
+def test_as_uncertainty_dict_loc_differs_from_amount_warns():
+    import warnings
+
+    for uncertainty_type in (0, 1):
+        given = {"uncertainty_type": uncertainty_type, "amount": 42.0, "loc": 99.0}
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            result = as_uncertainty_dict(given)
+        assert len(w) == 1
+        assert "Monte Carlo" in str(w[0].message)
+        assert result["loc"] == 99.0
+
+
 @bw2test
 def test_get_node_normal():
     Database("biosphere").write(biosphere)


### PR DESCRIPTION
Fixes #271.

## Summary

- In `as_uncertainty_dict`, when `uncertainty_type` is `UndefinedUncertainty` (0) or `NoUncertainty` (1) and `loc` is absent or NaN, set `loc = amount`. This prevents NaN from propagating into the distributions vector of characterisation matrix datapackages during Monte Carlo runs.
- If `loc` is explicitly set but differs from `amount` for these deterministic types, a warning is emitted but the value is kept as-is.
- Replace raw integer literals in `POSITIVE_DISTRIBUTIONS` with `stats_arrays` class IDs (`sa.LognormalUncertainty.id`, etc.) for readability.

## Test plan

- [ ] Existing `tests/utils.py` suite passes (33 tests, verified locally)
- [ ] Add a test for `as_uncertainty_dict` with `uncertainty_type=0`/`1` and `loc=NaN` to confirm it is replaced by `amount`
- [ ] Add a test that a warning is raised when `loc != amount` for these types