### PR TITLE
Fix error when passing MethodConfig object in get_multilca_data_objs

### DIFF
--- a/bw2data/compat.py
+++ b/bw2data/compat.py
@@ -19,7 +19,7 @@ from bw2data.backends import Node
 from bw2data.backends.schema import ActivityDataset as AD
 from bw2data.backends.schema import get_id
 from bw2data.errors import Brightway2Project, UnknownObject
-
+from bw2calc import MethodConfig
 
 class Mapping:
     """A dictionary that maps object ids, like ``("Ecoinvent 2.2", 42)``, to integers.
@@ -155,6 +155,9 @@ def get_multilca_data_objs(
     """Get all the datapackages needed for a complete MultiLCA calculation."""
     input_database_names = set()
 
+    if isinstance(method_config, MethodConfig):
+        method_config = method_config.model_dump()
+
     for v_dict in functional_units.values():
         for obj in v_dict:
             if not isinstance(obj, int):
@@ -171,19 +174,20 @@ def get_multilca_data_objs(
     )
     data_objs = [Database(obj).datapackage() for obj in complete_database_names]
 
-    for ic in set(method_config.get("impact_categories", [])):
-        if ic not in methods:
-            raise ValueError(f"Impact category (`Method`) {ic} not in this project")
-        data_objs.append(Method(ic).datapackage())
-
-    for n in method_config.get("normalizations", []):
-        if n not in normalizations:
-            raise ValueError(f"Normalization {n} not in this project")
-        data_objs.append(Normalization(n).datapackage())
-
-    for w in method_config.get("weightings", []):
-        if w not in weightings:
-            raise ValueError(f"Weighting {w} not in this project")
-        data_objs.append(Weighting(w).datapackage())
+    if method_config.get("impact_categories", []):
+        for ic in set(method_config.get("impact_categories", [])):
+            if ic not in methods:
+                raise ValueError(f"Impact category (`Method`) {ic} not in this project")
+            data_objs.append(Method(ic).datapackage())
+    if method_config.get("normalizations", []):
+        for n in method_config.get("normalizations", []):
+            if n not in normalizations:
+                raise ValueError(f"Normalization {n} not in this project")
+            data_objs.append(Normalization(n).datapackage())
+    if method_config.get("weightings", []):
+        for w in method_config.get("weightings", []):
+            if w not in weightings:
+                raise ValueError(f"Weighting {w} not in this project")
+            data_objs.append(Weighting(w).datapackage())
 
     return data_objs

--- a/bw2data/compat.py
+++ b/bw2data/compat.py
@@ -19,7 +19,7 @@ from bw2data.backends import Node
 from bw2data.backends.schema import ActivityDataset as AD
 from bw2data.backends.schema import get_id
 from bw2data.errors import Brightway2Project, UnknownObject
-from bw2calc import MethodConfig
+
 
 class Mapping:
     """A dictionary that maps object ids, like ``("Ecoinvent 2.2", 42)``, to integers.
@@ -155,8 +155,8 @@ def get_multilca_data_objs(
     """Get all the datapackages needed for a complete MultiLCA calculation."""
     input_database_names = set()
 
-    if isinstance(method_config, MethodConfig):
-        method_config = method_config.model_dump()
+    if hasattr(method_config, "impact_categories") and hasattr(method_config, "model_dump"):
+        method_config = method_config.model_dump(exclude_none=True)
 
     for v_dict in functional_units.values():
         for obj in v_dict:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,6 @@ requires-python = ">=3.9"
 dependencies = [
     "blinker",
     "bw2parameters",
-    "bw2calc",
     "bw_processing>=0.9.5",
     "deepdiff~=7.0.1",
     "deprecated",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,6 +31,7 @@ requires-python = ">=3.9"
 dependencies = [
     "blinker",
     "bw2parameters",
+    "bw2calc",
     "bw_processing>=0.9.5",
     "deepdiff~=7.0.1",
     "deprecated",

--- a/tests/compatibility.py
+++ b/tests/compatibility.py
@@ -320,3 +320,73 @@ def test_get_multilca_data_objs_errors_missing_w():
                 "weightings": {("weight",): [("normal",)]},
             },
         )
+
+
+@bw2test
+def test_get_multilca_data_objs_complete_method_config():
+    bw2calc = pytest.importorskip("bw2calc")
+    Database("biosphere").write(biosphere)
+    Database("food").write(food)
+    Database("food2").write(food2)
+    Method(("foo",)).write(lcia)
+    Normalization(("normal",)).write(
+        [
+            (("biosphere", "1"), 10),
+            (("biosphere", "2"), 20),
+        ]
+    )
+    Weighting(("weight",)).write([42])
+
+    objs = get_multilca_data_objs(
+        functional_units={
+            "a": {get_activity(("food", "1")).id: 1},
+            "b": {get_activity(("food2", "2")).id: 2},
+        },
+        method_config=bw2calc.MethodConfig(
+            impact_categories=[("foo",)],
+            normalizations={("normal",): [("foo",)]},
+            weightings={("weight",): [("normal",)]},
+        ),
+    )
+    object_names = [obj.metadata["name"] for obj in objs]
+
+    assert Database("biosphere").datapackage().metadata["name"] in object_names
+    assert Database("food").datapackage().metadata["name"] in object_names
+    assert Database("food2").datapackage().metadata["name"] in object_names
+    assert Normalization(("normal",)).datapackage().metadata["name"] in object_names
+    assert Weighting(("weight",)).datapackage().metadata["name"] in object_names
+    assert Method(("foo",)).datapackage().metadata["name"] in object_names
+
+
+@bw2test
+def test_get_multilca_data_objs_partial_method_config():
+    bw2calc = pytest.importorskip("bw2calc")
+    Database("biosphere").write(biosphere)
+    Database("food").write(food)
+    Database("food2").write(food2)
+    Method(("foo",)).write(lcia)
+    Normalization(("normal",)).write(
+        [
+            (("biosphere", "1"), 10),
+            (("biosphere", "2"), 20),
+        ]
+    )
+    Weighting(("weight",)).write([42])
+
+    objs = get_multilca_data_objs(
+        functional_units={
+            "a": {get_activity(("food", "1")).id: 1},
+            "b": {get_activity(("food2", "2")).id: 2},
+        },
+        method_config=bw2calc.MethodConfig(
+            impact_categories=[("foo",)],
+        ),
+    )
+    object_names = [obj.metadata["name"] for obj in objs]
+
+    assert Database("biosphere").datapackage().metadata["name"] in object_names
+    assert Database("food").datapackage().metadata["name"] in object_names
+    assert Database("food2").datapackage().metadata["name"] in object_names
+    assert Normalization(("normal",)).datapackage().metadata["name"] not in object_names
+    assert Weighting(("weight",)).datapackage().metadata["name"] not in object_names
+    assert Method(("foo",)).datapackage().metadata["name"] in object_names


### PR DESCRIPTION
Allows MethodConfig objecto to be passed as method_config argument in get_multilca_data_objs() by dump model to dictionary and add check if the method_config values are not None. 

I needed to add the bw2calc dependency to check if method_config is a MethodConfig class. 

closes #237