### PR TITLE
Fix missing logs directory causing FileNotFoundError (closes #239)

### DIFF
--- a/bw2data/logs.py
+++ b/bw2data/logs.py
@@ -25,7 +25,9 @@ class FakeLog:
 
 def get_logger(name, level=logging.INFO):
     from bw2data import projects
+    from bw2data.filesystem import create_dir
 
+    create_dir(projects.logs_dir)
     filename = "{}-{}.log".format(
         name,
         datetime.datetime.now().strftime("%d-%B-%Y-%I-%M%p"),
@@ -81,8 +83,10 @@ def get_structlog_stdout_feedback_logger(level: int = logging.INFO):
 def get_io_logger(name):
     """Build a logger that records only relevent data for display later as HTML."""
     from bw2data import projects
+    from bw2data.filesystem import create_dir
     from bw2data.utils import random_string
 
+    create_dir(projects.logs_dir)
     filepath = projects.logs_dir / "{}.{}.log".format(name, random_string(6))
     handler = logging.StreamHandler(codecs.open(filepath, "w", "utf-8"))
     logger = logging.getLogger(name)
@@ -95,7 +99,9 @@ def get_io_logger(name):
 
 def get_verbose_logger(name, level=logging.WARNING):
     from bw2data import projects
+    from bw2data.filesystem import create_dir
 
+    create_dir(projects.logs_dir)
     filename = "{}-{}.log".format(
         name,
         datetime.datetime.now().strftime("%d-%B-%Y-%I-%M%p"),

--- a/bw2data/project.py
+++ b/bw2data/project.py
@@ -505,7 +505,7 @@ class ProjectManager(Iterable):
         project_data = ProjectDataset.get(ProjectDataset.name == self.current).data
         ProjectDataset.create(data=project_data, name=new_name, full_hash=self.dataset.full_hash)
         shutil.copytree(self.dir, fp)
-        create_dir(self._base_logs_dir / safe_filename(new_name))
+        create_dir(self._base_logs_dir / safe_filename(new_name, full=self.dataset.full_hash))
         if switch:
             self.set_current(new_name)
 
@@ -551,10 +551,11 @@ class ProjectManager(Iterable):
         if len(self) == 1:
             raise ValueError("Can't delete only remaining project")
 
+        victim_dataset = ProjectDataset.get(ProjectDataset.name == victim)
         ProjectDataset.delete().where(ProjectDataset.name == victim).execute()
 
         if delete_dir:
-            dir_path = self._base_data_dir / safe_filename(victim)
+            dir_path = self._base_data_dir / safe_filename(victim, full=victim_dataset.full_hash)
             assert dir_path.is_dir(), "Can't find project directory"
             for _, substitutable_db in config.sqlite3_databases:
                 try:
@@ -564,6 +565,9 @@ class ProjectManager(Iterable):
                 except Exception:
                     pass
             shutil.rmtree(dir_path)
+            logs_path = self._base_logs_dir / safe_filename(victim, full=victim_dataset.full_hash)
+            if logs_path.is_dir():
+                shutil.rmtree(logs_path)
         else:
             stdout_feedback_logger.warning(
                 f"Removing project from project {name} list, but not deleting data; if you switch "
@@ -582,7 +586,7 @@ class ProjectManager(Iterable):
         """Delete project directories for projects which are no longer registered.
 
         Returns number of directories deleted."""
-        registered = {safe_filename(obj.name) for obj in self}
+        registered = {safe_filename(obj.name, full=obj.full_hash) for obj in self}
         bad_directories = [
             self._base_data_dir / dirname
             for dirname in os.listdir(self._base_data_dir)
@@ -592,7 +596,16 @@ class ProjectManager(Iterable):
         for fp in bad_directories:
             shutil.rmtree(fp)
 
-        return len(bad_directories)
+        bad_log_dirs = [
+            self._base_logs_dir / dirname
+            for dirname in os.listdir(self._base_logs_dir)
+            if (self._base_logs_dir / dirname).is_dir() and dirname not in registered
+        ]
+
+        for fp in bad_log_dirs:
+            shutil.rmtree(fp)
+
+        return len(bad_directories) + len(bad_log_dirs)
 
     def report(self):
         """Give a report on current projects, including installed databases and file sizes.


### PR DESCRIPTION
## Summary

- `purge_deleted_directories()` built its `registered` set using `safe_filename(name)` without `full_hash`, so projects created with `full_hash=True` had directory names that didn't match — they were treated as orphans and deleted, breaking the project and leaving a stale logs path.
- `purge_deleted_directories()` never cleaned up orphaned log directories under `_base_logs_dir`.
- `delete_project(delete_dir=True)` did not delete the matching log directory, and also computed the data-directory path without `full_hash`.
- `copy_project()` created the new log directory ignoring `full_hash`.
- All three log functions (`get_logger`, `get_io_logger`, `get_verbose_logger`) now defensively call `create_dir(projects.logs_dir)` before opening any file.

## Test plan

- [ ] All 168 existing tests pass (`pytest tests/ --ignore=tests/test_create_aggregated_process.py`)
- [ ] Reproduce the steps from #239 (create project, delete, purge, re-create, purge again, trigger logging) and confirm no `FileNotFoundError`
- [ ] Verify `delete_project(delete_dir=True)` removes both the data and logs directories for a full-hash project
- [ ] Verify `purge_deleted_directories()` return count now includes cleaned-up log directories