### PR TITLE
Implement filter and mask for FTS search

### DIFF
--- a/bw2data/search/indices.py
+++ b/bw2data/search/indices.py
@@ -1,5 +1,4 @@
 import os
-import warnings
 
 from peewee import SqliteDatabase
 
@@ -108,17 +107,6 @@ class IndexManager:
         )
 
     def search(self, string, limit=None, weights=None, mask=None, filter=None):
-        if mask:
-            warnings.warn(
-                "`mask` functionality has been deleted, and now does nothing. This input argument will be removed in the future",
-                DeprecationWarning,
-            )
-        if filter:
-            warnings.warn(
-                "`filter` functionality has been deleted, and now does nothing. This input argument will be removed in the future",
-                DeprecationWarning,
-            )
-
         with self.db.connection_context():
             with self.db.bind_ctx(MODELS):
                 if string == "*":
@@ -128,7 +116,10 @@ class IndexManager:
                         self.escape_search_for_fts5(string),
                         weights=weights,
                     )
-                return list(
+                # Skip SQL-level limit when post-filtering is needed so we don't
+                # prematurely discard results that would survive the filter/mask step.
+                sql_limit = None if (filter or mask) else limit
+                results = list(
                     query.select(
                         BW2Schema.name,
                         BW2Schema.comment,
@@ -139,7 +130,23 @@ class IndexManager:
                         BW2Schema.database,
                         BW2Schema.code,
                     )
-                    .limit(limit)
+                    .limit(sql_limit)
                     .dicts()
                     .execute()
                 )
+
+        if filter:
+            normalized = {k: v.lower() if isinstance(v, str) else v for k, v in filter.items()}
+            results = [
+                r for r in results
+                if all(str(normalized[k]) in r.get(k, "") for k in normalized)
+            ]
+        if mask:
+            normalized = {k: v.lower() if isinstance(v, str) else v for k, v in mask.items()}
+            results = [
+                r for r in results
+                if not any(str(normalized[k]) in r.get(k, "") for k in normalized)
+            ]
+        if limit is not None:
+            results = results[:limit]
+        return results

--- a/bw2data/search/search.py
+++ b/bw2data/search/search.py
@@ -58,6 +58,10 @@ class Searcher:
         kwargs = {"limit": limit}
         if facet:
             kwargs.pop("limit")
+        if filter:
+            kwargs["filter"] = filter
+        if mask:
+            kwargs["mask"] = mask
 
         with self:
             try:

--- a/tests/search.py
+++ b/tests/search.py
@@ -396,6 +396,100 @@ def test_search_with_special_chars():
         ]
 
 
+@bw2test
+def test_filter_by_location():
+    im = IndexManager("foo")
+    im.add_datasets(
+        [
+            {"database": "foo", "code": "bar", "name": "electricity", "location": "MX"},
+            {"database": "foo", "code": "baz", "name": "electricity", "location": "DE"},
+        ]
+    )
+    with Searcher("foo") as s:
+        results = s.search("electricity", proxy=False, filter={"location": "MX"})
+    assert len(results) == 1
+    assert results[0]["location"] == "mx"
+    assert results[0]["code"] == "bar"
+
+
+@bw2test
+def test_filter_by_location_case_insensitive():
+    im = IndexManager("foo")
+    im.add_datasets(
+        [
+            {"database": "foo", "code": "bar", "name": "electricity", "location": "MX"},
+            {"database": "foo", "code": "baz", "name": "electricity", "location": "DE"},
+        ]
+    )
+    with Searcher("foo") as s:
+        results = s.search("electricity", proxy=False, filter={"location": "mx"})
+    assert len(results) == 1
+    assert results[0]["code"] == "bar"
+
+
+@bw2test
+def test_filter_by_categories():
+    im = IndexManager("foo")
+    im.add_datasets(
+        [
+            {
+                "database": "foo",
+                "code": "bar",
+                "name": "electricity",
+                "categories": ("air",),
+            },
+            {
+                "database": "foo",
+                "code": "baz",
+                "name": "electricity",
+                "categories": ("water",),
+            },
+        ]
+    )
+    with Searcher("foo") as s:
+        results = s.search("electricity", proxy=False, filter={"categories": "air"})
+    assert len(results) == 1
+    assert results[0]["code"] == "bar"
+
+
+@bw2test
+def test_filter_no_match_returns_empty():
+    im = IndexManager("foo")
+    im.add_dataset({"database": "foo", "code": "bar", "name": "electricity", "location": "DE"})
+    with Searcher("foo") as s:
+        results = s.search("electricity", proxy=False, filter={"location": "MX"})
+    assert results == []
+
+
+@bw2test
+def test_mask_excludes_results():
+    im = IndexManager("foo")
+    im.add_datasets(
+        [
+            {"database": "foo", "code": "bar", "name": "electricity", "location": "MX"},
+            {"database": "foo", "code": "baz", "name": "electricity", "location": "DE"},
+        ]
+    )
+    with Searcher("foo") as s:
+        results = s.search("electricity", proxy=False, mask={"location": "MX"})
+    assert len(results) == 1
+    assert results[0]["code"] == "baz"
+
+
+@bw2test
+def test_filter_respects_limit():
+    im = IndexManager("foo")
+    im.add_datasets(
+        [
+            {"database": "foo", "code": str(i), "name": "electricity", "location": "MX"}
+            for i in range(10)
+        ]
+    )
+    with Searcher("foo") as s:
+        results = s.search("electricity", proxy=False, filter={"location": "MX"}, limit=5)
+    assert len(results) == 5
+
+
 def test_escape_search():
     assert (
         IndexManager.escape_search_for_fts5("Comte cheese from cow's")


### PR DESCRIPTION
Fixes #195

## Summary

- `filter` and `mask` parameters in `db.search()` were silently ignored (they emitted deprecation warnings saying the functionality was "deleted")
- Restored the feature: `filter` keeps only results where all criteria match; `mask` removes results where any criteria match
- Comparison is case-insensitive substring matching, consistent with how all values are stored lowercase in the FTS index
- When filter/mask is active, the SQL `LIMIT` is deferred until after Python-side filtering so results aren't prematurely truncated

## Test plan

- [ ] `test_filter_by_location` — `filter={"location": "MX"}` returns only MX results
- [ ] `test_filter_by_location_case_insensitive` — filter values are case-insensitive
- [ ] `test_filter_by_categories` — substring match works for comma-joined categories
- [ ] `test_filter_no_match_returns_empty` — returns `[]` when nothing passes the filter
- [ ] `test_mask_excludes_results` — `mask={"location": "MX"}` removes MX results
- [ ] `test_filter_respects_limit` — `limit` is applied after filtering