### PR TITLE
Fix unhelpful error when method/weighting/normalization missing in prepare_lca_inputs

### DIFF
--- a/bw2data/compat.py
+++ b/bw2data/compat.py
@@ -124,13 +124,25 @@ def prepare_lca_inputs(
             }
 
     if method:
-        assert method in methods
+        if method not in methods:
+            raise ValueError(
+                f"Method {method} not found in this project. "
+                "Use `bw2data.methods` to list available methods."
+            )
         data_objs.append(Method(method).datapackage())
     if weighting:
-        assert weighting in weightings
+        if weighting not in weightings:
+            raise ValueError(
+                f"Weighting {weighting} not found in this project. "
+                "Use `bw2data.weightings` to list available weightings."
+            )
         data_objs.append(Weighting(weighting).datapackage())
     if normalization:
-        assert normalization in normalizations
+        if normalization not in normalizations:
+            raise ValueError(
+                f"Normalization {normalization} not found in this project. "
+                "Use `bw2data.normalizations` to list available normalizations."
+            )
         data_objs.append(Normalization(normalization).datapackage())
 
     if demands:

--- a/tests/compatibility.py
+++ b/tests/compatibility.py
@@ -137,6 +137,11 @@ def test_prepare_lca_inputs_remapping(setup):
     assert r is None
 
 
+def test_prepare_lca_inputs_missing_method(setup):
+    with pytest.raises(ValueError, match="Method.*not found"):
+        prepare_lca_inputs(demand={("food", "1"): 1}, method=("does_not_exist",))
+
+
 @bw2test
 def test_get_multilca_data_objs_complete():
     Database("biosphere").write(biosphere)

--- a/tests/compatibility.py
+++ b/tests/compatibility.py
@@ -137,9 +137,17 @@ def test_prepare_lca_inputs_remapping(setup):
     assert r is None
 
 
-def test_prepare_lca_inputs_missing_method(setup):
-    with pytest.raises(ValueError, match="Method.*not found"):
-        prepare_lca_inputs(demand={("food", "1"): 1}, method=("does_not_exist",))
+@pytest.mark.parametrize(
+    "kwargs,match",
+    [
+        ({"method": ("does_not_exist",)}, "Method.*not found"),
+        ({"weighting": ("does_not_exist",)}, "Weighting.*not found"),
+        ({"normalization": ("does_not_exist",)}, "Normalization.*not found"),
+    ],
+)
+def test_prepare_lca_inputs_missing_element(setup, kwargs, match):
+    with pytest.raises(ValueError, match=match):
+        prepare_lca_inputs(demand={("food", "1"): 1}, **kwargs)
 
 
 @bw2test


### PR DESCRIPTION
## Summary

- Closes #168
- Replaces bare `assert` statements in `prepare_lca_inputs` with `ValueError` raises that name the missing object and direct users to `bw2data.methods`, `bw2data.weightings`, or `bw2data.normalizations` to list available options
- Adds a test covering the missing method case

## Test plan

- [ ] `tests/compatibility.py::test_prepare_lca_inputs_missing_method` — new test verifying `ValueError` with helpful message is raised
- [ ] `tests/compatibility.py::test_prepare_lca_inputs_basic` — existing test still passes
- [ ] `tests/compatibility.py::test_prepare_lca_inputs_only_method` — existing test still passes