### PR TITLE
Fix blinker signal.send() calls to pass sender as first positional argument

### DIFF
--- a/bw2data/meta.py
+++ b/bw2data/meta.py
@@ -122,7 +122,7 @@ Metadata state is unchanged, but database state is unknown.
         super(Databases, self).__delitem__(name=name, signal=False)
 
         if signal:
-            on_database_delete.send(name=name)
+            on_database_delete.send(self, name=name)
 
 
 class CalculationSetups(PickledDict):

--- a/bw2data/parameters.py
+++ b/bw2data/parameters.py
@@ -201,7 +201,7 @@ class ProjectParameter(ParameterBase):
             ProjectParameter.expire_downstream("project")
 
         if signal:
-            on_project_parameter_recalculate.send()
+            on_project_parameter_recalculate.send(ProjectParameter)
 
     @staticmethod
     def dependency_chain():
@@ -270,7 +270,7 @@ class ProjectParameter(ParameterBase):
 
         if signal:
             on_project_parameter_update_formula_parameter_name.send(
-                old={"old": old}, new={"new": new}
+                cls, old={"old": old}, new={"new": new}
             )
 
     @property
@@ -401,7 +401,7 @@ class DatabaseParameter(ParameterBase):
             DatabaseParameter.expire_downstream(database)
 
         if signal:
-            on_database_parameter_recalculate.send(name=database)
+            on_database_parameter_recalculate.send(DatabaseParameter, name=database)
 
     @staticmethod
     def dependency_chain(group, include_self=False):
@@ -534,7 +534,7 @@ class DatabaseParameter(ParameterBase):
 
         if signal:
             on_database_parameter_update_formula_project_parameter_name.send(
-                old={"old": old}, new={"new": new}
+                cls, old={"old": old}, new={"new": new}
             )
 
     @classmethod
@@ -560,7 +560,7 @@ class DatabaseParameter(ParameterBase):
 
         if signal:
             on_database_parameter_update_formula_database_parameter_name.send(
-                old={"old": old}, new={"new": new}
+                cls, old={"old": old}, new={"new": new}
             )
 
     @property
@@ -855,7 +855,7 @@ class ActivityParameter(ParameterBase):
         ActivityParameter.recalculate_exchanges(group, signal=False)
 
         if signal:
-            on_activity_parameter_recalculate.send(name=group)
+            on_activity_parameter_recalculate.send(ActivityParameter, name=group)
 
     @staticmethod
     def recalculate_exchanges(group: str, signal: bool = True):
@@ -875,7 +875,7 @@ class ActivityParameter(ParameterBase):
         databases.set_dirty(ActivityParameter.get(group=group).database)
 
         if signal:
-            on_activity_parameter_recalculate_exchanges.send(name=group)
+            on_activity_parameter_recalculate_exchanges.send(ActivityParameter, name=group)
 
     def save(self, *args, **kwargs):
         """Save this model instance"""
@@ -956,7 +956,7 @@ class ActivityParameter(ParameterBase):
 
         if signal:
             on_activity_parameter_update_formula_project_parameter_name.send(
-                old={"old": old}, new={"new": new}
+                cls, old={"old": old}, new={"new": new}
             )
 
     @classmethod
@@ -1004,7 +1004,7 @@ class ActivityParameter(ParameterBase):
 
         if signal:
             on_activity_parameter_update_formula_database_parameter_name.send(
-                old={"old": old}, new={"new": new}
+                cls, old={"old": old}, new={"new": new}
             )
 
     @classmethod
@@ -1045,7 +1045,7 @@ class ActivityParameter(ParameterBase):
 
         if signal:
             on_activity_parameter_update_formula_activity_parameter_name.send(
-                old={"old": old}, new={"new": new, "include_order": include_order}
+                cls, old={"old": old}, new={"new": new, "include_order": include_order}
             )
 
     @classmethod

--- a/bw2data/project.py
+++ b/bw2data/project.py
@@ -427,7 +427,7 @@ class ProjectManager(Iterable):
         self.dataset = ProjectDataset.get(ProjectDataset.name == self._project_name)
         self._reset_meta()
         self._reset_sqlite3_databases()
-        project_changed.send(self.dataset)
+        project_changed.send(self, dataset=self.dataset)
 
         if not writable:
             self.read_only = True
@@ -489,7 +489,7 @@ class ProjectManager(Iterable):
             self.dataset = ProjectDataset.get(ProjectDataset.name == name)
         except DoesNotExist:
             self.dataset = ProjectDataset.create(data=kwargs, name=name, full_hash=full_hash)
-            project_created.send(self.dataset)
+            project_created.send(self, dataset=self.dataset)
         create_dir(self.dir)
         for dir_name in self._basic_directories:
             create_dir(self.dir / dir_name)

--- a/bw2data/serialization.py
+++ b/bw2data/serialization.py
@@ -201,7 +201,7 @@ class SerializedDict(MutableMapping):
             f.write(JsonWrapper.dumps(self.pack(self.data)))
 
         if signal and hasattr(self, "_save_signal"):
-            self._save_signal.send(old=previous, new=deepcopy(self.data))
+            self._save_signal.send(self, old=previous, new=deepcopy(self.data))
 
     def deserialize(self):
         """Load the serialized data. Can be replaced with other serialization formats."""
@@ -239,7 +239,7 @@ class PickledDict(SerializedDict):
             pickle.dump(self.pack(self.data), f, protocol=4)
 
         if signal and hasattr(self, "_save_signal"):
-            self._save_signal.send(old=previous, new=deepcopy(self.data))
+            self._save_signal.send(self, old=previous, new=deepcopy(self.data))
 
     def deserialize(self):
         try:

--- a/bw2data/signals.py
+++ b/bw2data/signals.py
@@ -248,6 +248,7 @@ class SignaledDataset(Model):
         super().save(*args, **kwargs)
         if signal:
             signaleddataset_on_save.send(
+                self,
                 old=old,
                 new=self,
             )
@@ -255,7 +256,7 @@ class SignaledDataset(Model):
     @override
     def delete_instance(self, signal: bool = True, *args, **kwargs) -> None:
         if signal:
-            signaleddataset_on_delete.send(old=self)
+            signaleddataset_on_delete.send(self, old=self)
         super().delete_instance(*args, **kwargs)
 
     # From the peewee docs

--- a/tests/test_signals.py
+++ b/tests/test_signals.py
@@ -5,8 +5,9 @@ from bw2data.tests import bw2test
 
 
 class SignalCatcher:
-    def __call__(self, arg):
-        self.arg = arg
+    def __call__(self, sender, **kwargs):
+        self.sender = sender
+        self.kwargs = kwargs
 
 
 @bw2test
@@ -15,8 +16,8 @@ def test_project_changed_signal():
     signal("bw2data.project_changed").connect(subscriber)
     projects.set_current("foo")
 
-    assert isinstance(subscriber.arg, ProjectDataset)
-    assert subscriber.arg.name == "foo"
+    assert isinstance(subscriber.kwargs["dataset"], ProjectDataset)
+    assert subscriber.kwargs["dataset"].name == "foo"
 
 
 @bw2test
@@ -25,5 +26,5 @@ def test_project_created_signal():
     signal("bw2data.project_created").connect(subscriber)
     projects.set_current("foo")
 
-    assert isinstance(subscriber.arg, ProjectDataset)
-    assert subscriber.arg.name == "foo"
+    assert isinstance(subscriber.kwargs["dataset"], ProjectDataset)
+    assert subscriber.kwargs["dataset"].name == "foo"


### PR DESCRIPTION
## Summary

Closes #220.

Per the [blinker `Signal.send()` documentation](https://blinker.readthedocs.io/en/stable/#blinker.Signal.send), the first positional argument must be the **sender** object. Without it, `sender` defaults to `None`, which prevents filtering connected receivers by sender via `signal.connect(receiver, sender=...)`.

- All `signal.send()` calls now pass a proper sender as the first positional argument
- In `project.py`, `self.dataset` was incorrectly used as the sender; it is now passed as a `dataset=` keyword argument with the `Projects` instance as the correct sender
- Updated `tests/test_signals.py` to use the corrected signal API (receiver accepts `sender, **kwargs`)

## Files changed

- `bw2data/signals.py` — `SignaledDataset.save/delete_instance`: pass `self` as sender
- `bw2data/project.py` — `project_changed/project_created`: pass `self` as sender, move dataset to `dataset=` kwarg
- `bw2data/meta.py` — `on_database_delete`: pass `self` as sender
- `bw2data/serialization.py` — both `_save_signal.send()` calls: pass `self` as sender
- `bw2data/parameters.py` — all 10 signal calls: static methods use the owning class, classmethods use `cls`
- `tests/test_signals.py` — updated `SignalCatcher` and assertions to match corrected API

## Breaking change

Receivers connected to `project_changed` and `project_created` that relied on the old broken behaviour (receiving `ProjectDataset` as the positional sender argument) must update their signature to `(sender, *, dataset, **kwargs)`. A companion fix has been submitted to `multifunctional` (#41).

## Test plan

- [x] All 178 existing tests pass (`pytest tests/ -x -q`)