### PR TITLE
Warn and set default type in Activity.save() when type not specified

### DIFF
--- a/bw2data/backends/proxies.py
+++ b/bw2data/backends/proxies.py
@@ -355,6 +355,13 @@ class Activity(ActivityProxyBase):
         databases.set_dirty(self["database"])
 
         if not data_already_set:
+            if "type" not in self._data:
+                warnings.warn(
+                    f"Activity {self.get('code')} in database '{self.get('database')}' has no "
+                    f"`type` specified; defaulting to '{labels.process_node_default}'",
+                    UserWarning,
+                )
+                self._data["type"] = labels.process_node_default
             check_activity_type(self._data.get("type"))
             check_activity_keys(self)
 

--- a/tests/unit/test_node_events.py
+++ b/tests/unit/test_node_events.py
@@ -37,6 +37,7 @@ def test_node_revision_expected_format_create():
                                 "database": "db",
                                 "location": "GLO",
                                 "name": "A",
+                                "type": "process",
                             },
                             "old_type": "NoneType",
                         }
@@ -549,6 +550,7 @@ def test_node_revision_expected_format_activity_copy():
                                     "database": "db",
                                     "location": "GLO",
                                     "name": "A",
+                                    "type": "process",
                                 },
                                 "old_type": "NoneType",
                             }
@@ -698,6 +700,7 @@ def test_node_revision_expected_format_activity_copy_new_database():
                                     "database": "db2",
                                     "location": "GLO",
                                     "name": "A",
+                                    "type": "process",
                                 },
                                 "old_type": "NoneType",
                             }


### PR DESCRIPTION
## Summary

- Fixes `Activity["type"]` raising `KeyError` when `type` was not explicitly set during activity creation (closes #218)
- In `Activity.save()`, if `"type"` is absent from the data dict, a `UserWarning` is now issued and the value is set to `labels.process_node_default` before the data blob is pickled
- This ensures the type is accessible via `activity["type"]` after a round-trip through the database

## Why only `type`

`location` and `product` (`"reference product"`) are genuinely optional fields that default to `None` — a `KeyError` for those is correct and callers should use `.get()`. Only `type` had a hidden default (`process_node_default`) being silently applied to the DB column without being stored in the data blob.