### PR TITLE
Skip coverage on Windows and macOS to speed up CI

### DIFF
--- a/.github/workflows/python-test.yml
+++ b/.github/workflows/python-test.yml
@@ -54,9 +54,16 @@ jobs:
         run: |
           uv pip install --system .[testing]
 
-      - name: Test with pytest
+      - name: Test with pytest (with coverage)
+        if: matrix.os == 'ubuntu-latest'
         run: |
           pytest
 
+      - name: Test with pytest (without coverage)
+        if: matrix.os != 'ubuntu-latest'
+        run: |
+          pytest --no-cov
+
       - name: Upload coverage reports to Codecov
+        if: matrix.os == 'ubuntu-latest'
         uses: codecov/codecov-action@v4


### PR DESCRIPTION
## Summary

- Run `pytest --no-cov` on Windows and macOS; keep full coverage only on Linux
- Restrict the Codecov upload step to Linux as well

## Motivation

Windows test jobs were taking **18–21 minutes** vs ~5 minutes on Linux — a 4–5× slowdown that is entirely in test execution time (setup with uv takes <25s). Coverage instrumentation is known to add measurable overhead, especially on Windows. This change avoids collecting it on the two slower platforms where we don't need the data anyway.