### PR TITLE
Add project_deleted signal (closes #228)

### DIFF
--- a/bw2data/project.py
+++ b/bw2data/project.py
@@ -19,7 +19,7 @@ from bw2data import config
 from bw2data.errors import InconsistentData, PossibleInconsistentData
 from bw2data.filesystem import create_dir
 from bw2data.logs import stdout_feedback_logger
-from bw2data.signals import project_changed, project_created
+from bw2data.signals import project_changed, project_created, project_deleted
 from bw2data.sqlite import PickleField, SubstitutableDatabase
 from bw2data.utils import maybe_path
 
@@ -553,6 +553,7 @@ class ProjectManager(Iterable):
 
         victim_dataset = ProjectDataset.get(ProjectDataset.name == victim)
         ProjectDataset.delete().where(ProjectDataset.name == victim).execute()
+        project_deleted.send(self, dataset=victim_dataset)
 
         if delete_dir:
             dir_path = self._base_data_dir / safe_filename(victim, full=victim_dataset.full_hash)

--- a/bw2data/signals.py
+++ b/bw2data/signals.py
@@ -239,6 +239,18 @@ No expected return value.
 """,
 )
 
+project_deleted = signal(
+    "bw2data.project_deleted",
+    doc="""
+Emitted when a project is deleted, after removal from the database but before any filesystem ops.
+
+Expected inputs:
+    * `bw2data.projects.ProjectDataset` instance
+
+No expected return value.
+""",
+)
+
 
 class SignaledDataset(Model):
     @override

--- a/tests/test_signals.py
+++ b/tests/test_signals.py
@@ -28,3 +28,14 @@ def test_project_created_signal():
 
     assert isinstance(subscriber.kwargs["dataset"], ProjectDataset)
     assert subscriber.kwargs["dataset"].name == "foo"
+
+
+@bw2test
+def test_project_deleted_signal():
+    projects.set_current("foo")
+    subscriber = SignalCatcher()
+    signal("bw2data.project_deleted").connect(subscriber)
+    projects.delete_project("foo")
+
+    assert isinstance(subscriber.kwargs["dataset"], ProjectDataset)
+    assert subscriber.kwargs["dataset"].name == "foo"


### PR DESCRIPTION
## Summary

- Adds `bw2data.project_deleted` signal to `signals.py`, consistent with the existing `project_changed` and `project_created` signals
- Emits the signal in `delete_project` after the project row is removed from the database, passing the `ProjectDataset` instance as `dataset=` keyword argument
- Adds a test covering the new signal

## Test plan

- [ ] `pytest tests/test_signals.py` — all 3 signal tests pass