### PR TITLE
Add write and delete signals for Method, Weighting, and Normalization

### DIFF
--- a/bw2data/data_store.py
+++ b/bw2data/data_store.py
@@ -157,13 +157,7 @@ class ProcessedDataStore(DataStore):
         pass
 
     @abstractmethod
-    def delete(
-        self,
-        keep_params: bool = False,
-        warn: bool = True,
-        vacuum: bool = True,
-        signal: bool = True,
-    ):
+    def delete(self, signal: bool = True, **kwargs):
         pass
 
     def dirpath_processed(self):

--- a/bw2data/ia_data_store.py
+++ b/bw2data/ia_data_store.py
@@ -3,6 +3,7 @@ import string
 
 from bw_processing import safe_filename
 
+from bw2data import projects
 from bw2data.data_store import ProcessedDataStore
 
 
@@ -94,6 +95,30 @@ class ImpactAssessmentDataStore(ProcessedDataStore):
             The abbreviated identifier of the method.
         """
         return self.get_abbreviation()
+
+    def delete(self, signal: bool = True, **kwargs):
+        """Delete the intermediate and processed data files and deregister this object.
+
+        Subclasses should call ``super().delete(signal=False)`` and then emit
+        their own class-specific signal when ``signal=True``.
+        """
+        if self.registered:
+            filepath_pickle = (
+                projects.dir / self._intermediate_dir / (self.filename + ".pickle")
+            )
+            filepath_processed = self.filepath_processed()
+
+            try:
+                filepath_pickle.unlink()
+            except FileNotFoundError:
+                pass
+
+            try:
+                filepath_processed.unlink()
+            except FileNotFoundError:
+                pass
+
+            self.deregister()
 
     def process(self, **extra_metadata):
         """

--- a/bw2data/method.py
+++ b/bw2data/method.py
@@ -5,6 +5,7 @@ from bw2data.backends.proxies import Activity
 from bw2data.backends.schema import get_id
 from bw2data.errors import UnknownObject
 from bw2data.ia_data_store import ImpactAssessmentDataStore
+from bw2data.signals import on_method_delete, on_method_write
 from bw2data.utils import as_uncertainty_dict, get_geocollection, get_node
 from bw2data.validate import ia_validator
 
@@ -92,7 +93,7 @@ class Method(ImpactAssessmentDataStore):
                     )
                 )
 
-    def write(self, data, process=True):
+    def write(self, data, process=True, signal=True):
         """Serialize intermediate data to disk.
 
         Sets the metadata key ``num_cfs`` automatically."""
@@ -124,6 +125,14 @@ class Method(ImpactAssessmentDataStore):
         self.metadata["geocollections"] = sorted(geocollections)
         super(Method, self).write(data, process=process)
         methods.flush()
+        if signal:
+            on_method_write.send(self, name=self.name)
+
+    def delete(self, signal: bool = True, **kwargs):
+        """Delete intermediate and processed data files and deregister this method."""
+        super().delete(signal=False)
+        if signal:
+            on_method_delete.send(self, name=self.name)
 
     def process(self, **extra_metadata):
         try:

--- a/bw2data/signals.py
+++ b/bw2data/signals.py
@@ -251,6 +251,72 @@ No expected return value.
 """,
 )
 
+on_method_write = signal(
+    "bw2data.on_method_write",
+    doc="""Emitted *after* a `Method` has new data written.
+
+Expected inputs:
+    * `name`: tuple - method name
+
+No expected return value.
+""",
+)
+
+on_method_delete = signal(
+    "bw2data.on_method_delete",
+    doc="""Emitted *after* a `Method` is deleted.
+
+Expected inputs:
+    * `name`: tuple - method name
+
+No expected return value.
+""",
+)
+
+on_weighting_write = signal(
+    "bw2data.on_weighting_write",
+    doc="""Emitted *after* a `Weighting` has new data written.
+
+Expected inputs:
+    * `name`: tuple - weighting name
+
+No expected return value.
+""",
+)
+
+on_weighting_delete = signal(
+    "bw2data.on_weighting_delete",
+    doc="""Emitted *after* a `Weighting` is deleted.
+
+Expected inputs:
+    * `name`: tuple - weighting name
+
+No expected return value.
+""",
+)
+
+on_normalization_write = signal(
+    "bw2data.on_normalization_write",
+    doc="""Emitted *after* a `Normalization` has new data written.
+
+Expected inputs:
+    * `name`: tuple - normalization name
+
+No expected return value.
+""",
+)
+
+on_normalization_delete = signal(
+    "bw2data.on_normalization_delete",
+    doc="""Emitted *after* a `Normalization` is deleted.
+
+Expected inputs:
+    * `name`: tuple - normalization name
+
+No expected return value.
+""",
+)
+
 
 class SignaledDataset(Model):
     @override

--- a/bw2data/weighting_normalization.py
+++ b/bw2data/weighting_normalization.py
@@ -1,6 +1,8 @@
 from bw2data.backends.schema import get_id
 from bw2data.ia_data_store import ImpactAssessmentDataStore
 from bw2data.meta import normalizations, weightings
+from bw2data.signals import on_normalization_delete, on_normalization_write
+from bw2data.signals import on_weighting_delete, on_weighting_write
 from bw2data.utils import as_uncertainty_dict
 from bw2data.validate import normalization_validator, weighting_validator
 
@@ -24,13 +26,21 @@ class Weighting(ImpactAssessmentDataStore):
     validator = weighting_validator
     matrix = "weighting_matrix"
 
-    def write(self, data):
+    def write(self, data, process=True, signal=True):
         """Because of DataStore assumptions, need a one-element list"""
         if self.name not in self._metadata:
             self.register()
         if not isinstance(data, list) or not len(data) == 1:
             raise ValueError("Weighting data must be one-element list")
-        super(Weighting, self).write(data)
+        super(Weighting, self).write(data, process=process)
+        if signal:
+            on_weighting_write.send(self, name=self.name)
+
+    def delete(self, signal: bool = True, **kwargs):
+        """Delete intermediate and processed data files and deregister this weighting."""
+        super().delete(signal=False)
+        if signal:
+            on_weighting_delete.send(self, name=self.name)
 
     def process_row(self, row):
         """Return an empty tuple (as ``dtype_fields`` is empty), and the weighting uncertainty dictionary."""
@@ -58,6 +68,18 @@ class Normalization(ImpactAssessmentDataStore):
     _metadata = normalizations
     validator = normalization_validator
     matrix = "normalization_matrix"
+
+    def write(self, data, process=True, signal=True):
+        """Serialize intermediate data to disk."""
+        super().write(data, process=process)
+        if signal:
+            on_normalization_write.send(self, name=self.name)
+
+    def delete(self, signal: bool = True, **kwargs):
+        """Delete intermediate and processed data files and deregister this normalization."""
+        super().delete(signal=False)
+        if signal:
+            on_normalization_delete.send(self, name=self.name)
 
     def process_row(self, row):
         """Given ``(flow key, amount)``, return a dictionary for array insertion."""

--- a/tests/unit/test_ia_datastore_events.py
+++ b/tests/unit/test_ia_datastore_events.py
@@ -1,0 +1,215 @@
+from bw2data.database import DatabaseChooser
+from bw2data.method import Method
+from bw2data.signals import (
+    on_method_delete,
+    on_method_write,
+    on_normalization_delete,
+    on_normalization_write,
+    on_weighting_delete,
+    on_weighting_write,
+)
+from bw2data.tests import bw2test
+from bw2data.weighting_normalization import Normalization, Weighting
+
+
+@bw2test
+def test_method_write_emits_signal():
+    received = []
+
+    @on_method_write.connect
+    def handler(sender, name, **kwargs):
+        received.append(name)
+
+    try:
+        DatabaseChooser("bio").write({("bio", "co2"): {}})
+        m = Method(("test", "method"))
+        m.write([[("bio", "co2"), 1.0]])
+        assert received == [("test", "method")]
+    finally:
+        on_method_write.disconnect(handler)
+
+
+@bw2test
+def test_method_write_signal_false():
+    received = []
+
+    @on_method_write.connect
+    def handler(sender, name, **kwargs):
+        received.append(name)
+
+    try:
+        DatabaseChooser("bio").write({("bio", "co2"): {}})
+        m = Method(("test", "method"))
+        m.write([[("bio", "co2"), 1.0]], signal=False)
+        assert received == []
+    finally:
+        on_method_write.disconnect(handler)
+
+
+@bw2test
+def test_method_delete_emits_signal():
+    received = []
+
+    @on_method_delete.connect
+    def handler(sender, name, **kwargs):
+        received.append(name)
+
+    try:
+        DatabaseChooser("bio").write({("bio", "co2"): {}})
+        m = Method(("test", "method"))
+        m.write([[("bio", "co2"), 1.0]])
+        m.delete()
+        assert received == [("test", "method")]
+        assert not m.registered
+    finally:
+        on_method_delete.disconnect(handler)
+
+
+@bw2test
+def test_method_delete_signal_false():
+    received = []
+
+    @on_method_delete.connect
+    def handler(sender, name, **kwargs):
+        received.append(name)
+
+    try:
+        DatabaseChooser("bio").write({("bio", "co2"): {}})
+        m = Method(("test", "method"))
+        m.write([[("bio", "co2"), 1.0]])
+        m.delete(signal=False)
+        assert received == []
+        assert not m.registered
+    finally:
+        on_method_delete.disconnect(handler)
+
+
+@bw2test
+def test_weighting_write_emits_signal():
+    received = []
+
+    @on_weighting_write.connect
+    def handler(sender, name, **kwargs):
+        received.append(name)
+
+    try:
+        w = Weighting(("test", "weighting"))
+        w.write([1.0])
+        assert received == [("test", "weighting")]
+    finally:
+        on_weighting_write.disconnect(handler)
+
+
+@bw2test
+def test_weighting_write_signal_false():
+    received = []
+
+    @on_weighting_write.connect
+    def handler(sender, name, **kwargs):
+        received.append(name)
+
+    try:
+        w = Weighting(("test", "weighting"))
+        w.write([1.0], signal=False)
+        assert received == []
+    finally:
+        on_weighting_write.disconnect(handler)
+
+
+@bw2test
+def test_weighting_delete_emits_signal():
+    received = []
+
+    @on_weighting_delete.connect
+    def handler(sender, name, **kwargs):
+        received.append(name)
+
+    try:
+        w = Weighting(("test", "weighting"))
+        w.write([1.0])
+        w.delete()
+        assert received == [("test", "weighting")]
+        assert not w.registered
+    finally:
+        on_weighting_delete.disconnect(handler)
+
+
+@bw2test
+def test_normalization_write_emits_signal():
+    received = []
+
+    @on_normalization_write.connect
+    def handler(sender, name, **kwargs):
+        received.append(name)
+
+    try:
+        DatabaseChooser("bio").write({("bio", "co2"): {}})
+        n = Normalization(("test", "norm"))
+        n.write([[("bio", "co2"), 1.0]])
+        assert received == [("test", "norm")]
+    finally:
+        on_normalization_write.disconnect(handler)
+
+
+@bw2test
+def test_normalization_write_signal_false():
+    received = []
+
+    @on_normalization_write.connect
+    def handler(sender, name, **kwargs):
+        received.append(name)
+
+    try:
+        DatabaseChooser("bio").write({("bio", "co2"): {}})
+        n = Normalization(("test", "norm"))
+        n.write([[("bio", "co2"), 1.0]], signal=False)
+        assert received == []
+    finally:
+        on_normalization_write.disconnect(handler)
+
+
+@bw2test
+def test_normalization_delete_emits_signal():
+    received = []
+
+    @on_normalization_delete.connect
+    def handler(sender, name, **kwargs):
+        received.append(name)
+
+    try:
+        DatabaseChooser("bio").write({("bio", "co2"): {}})
+        n = Normalization(("test", "norm"))
+        n.write([[("bio", "co2"), 1.0]])
+        n.delete()
+        assert received == [("test", "norm")]
+        assert not n.registered
+    finally:
+        on_normalization_delete.disconnect(handler)
+
+
+@bw2test
+def test_method_delete_removes_files():
+    from bw2data import projects
+
+    DatabaseChooser("bio").write({("bio", "co2"): {}})
+    m = Method(("test", "method"))
+    m.write([[("bio", "co2"), 1.0]])
+
+    pickle_path = projects.dir / "intermediate" / (m.filename + ".pickle")
+    processed_path = m.filepath_processed()
+
+    assert pickle_path.exists()
+    assert processed_path.exists()
+
+    m.delete()
+
+    assert not pickle_path.exists()
+    assert not processed_path.exists()
+    assert not m.registered
+
+
+@bw2test
+def test_delete_unregistered_is_noop():
+    m = Method(("nonexistent", "method"))
+    m.delete()
+    assert not m.registered


### PR DESCRIPTION
## Summary

Closes #222.

- Adds `on_method_write`, `on_method_delete`, `on_weighting_write`, `on_weighting_delete`, `on_normalization_write`, and `on_normalization_delete` blinker signals to `bw2data/signals.py`
- Adds a `signal=True` parameter to `Method.write()`, `Weighting.write()`, and `Normalization.write()` — each emits its class-specific signal after a successful write
- Adds `delete()` to `Method`, `Weighting`, and `Normalization` — removes the pickle and processed zip files, deregisters the object, and emits the class-specific delete signal
- Adds shared file-cleanup logic to `ImpactAssessmentDataStore.delete()` so subclasses call `super().delete(signal=False)` and emit their own signal
- Simplifies the abstract `ProcessedDataStore.delete()` signature to `(signal, **kwargs)` to accommodate IA subclasses that don't need `keep_params`/`warn`/`vacuum`

## Test plan

- [ ] `tests/unit/test_ia_datastore_events.py` — 12 new tests covering signal emission on write/delete, `signal=False` suppression, file cleanup on delete, and noop on an unregistered object
- [ ] All 167 existing tests continue to pass