### PR TITLE
Fix KeyError when deleting activity that has calculation setups (closes #256)

### DIFF
--- a/bw2data/backends/proxies.py
+++ b/bw2data/backends/proxies.py
@@ -287,7 +287,7 @@ class Activity(ActivityProxyBase):
             return {
                 key: value
                 for key, value in dct.items()
-                if key != obj._data["id"] and key != (obj._data["database"], obj._data["code"])
+                if key != obj.id and key != obj.key
             }
 
         try:
@@ -304,7 +304,7 @@ class Activity(ActivityProxyBase):
 
         for name, setup in calculation_setups.items():
             if any(
-                (key == self._data["id"] or key == (self._data["database"], self._data["code"]))
+                (key == self.id or key == self.key)
                 for func_unit in setup["inv"]
                 for key in func_unit
             ):

--- a/tests/activity_proxy.py
+++ b/tests/activity_proxy.py
@@ -462,6 +462,24 @@ def test_delete_calculation_setups(capsys):
 
 
 @bw2test
+def test_delete_calculation_setups_without_refetch(capsys):
+    """Deleting a freshly-saved activity (never reloaded via get_node) must not raise KeyError.
+    Regression test for https://github.com/brightway-lca/brightway2-data/issues/256"""
+    db = DatabaseChooser("example")
+    db.register()
+
+    a = db.new_activity(code="A", name="An activity")
+    a.save()
+    b = db.new_activity(code="B", name="Another activity")
+    b.save()
+
+    calculation_setups["foo"] = {"inv": [{a.key: 1}, {b.key: 2}]}
+
+    b.delete()
+    assert calculation_setups["foo"]["inv"] == [{a.key: 1}]
+
+
+@bw2test
 def test_get_classifications_ref_product_no_longer_works_4_3():
     db = DatabaseChooser("example")
     db.register()


### PR DESCRIPTION
## Summary

- In `Activity.delete()`, the `purge()` helper and the calculation-setup loop were reading `self._data["id"]`, `self._data["database"]`, and `self._data["code"]` directly from the internal dict.
- `_data["id"]` is only populated when an activity is *loaded* from the database (e.g. via `get_node()`). A freshly-created activity that has been `save()`d but never reloaded does not have `"id"` in `_data`, causing a `KeyError`.
- Fix: use `self.id` (→ `self._document.id`) and `self.key` instead, which are always valid regardless of how the activity was constructed.

## Test plan

- [ ] Existing `test_delete_calculation_setups` still passes (covers the reload-via-`get_node` path)
- [ ] New `test_delete_calculation_setups_without_refetch` covers the exact scenario from the issue: create, save, delete without reloading