### PR TITLE
Copy parameters on Database.copy() (closes #242)

### DIFF
--- a/bw2data/backends/base.py
+++ b/bw2data/backends/base.py
@@ -234,7 +234,116 @@ class SQLiteBackend(ProcessedDataStore):
             new_database.register(**metadata)
 
         new_database.write(data, searchable=databases[name].get("searchable"))
+        self._copy_parameters(name)
         return new_database
+
+    def _copy_parameters(self, new_name: str) -> None:
+        """Copy parameters from this database to ``new_name``.
+
+        Copies DatabaseParameter, ActivityParameter, and ParameterizedExchange records.
+        ActivityParameter groups get new names (``{old_group}__{new_name}``) because groups
+        are single-database and the original groups still hold the old database's records.
+        """
+        from bw2data.parameters import (
+            ActivityParameter,
+            DatabaseParameter,
+            Group,
+            GroupDependency,
+            ParameterizedExchange,
+        )
+
+        old_name = self.name
+
+        # Copy DatabaseParameters (group name == database name, so new group is created via save())
+        for dp in DatabaseParameter.select().where(DatabaseParameter.database == old_name):
+            DatabaseParameter.create(
+                database=new_name,
+                name=dp.name,
+                formula=dp.formula,
+                amount=dp.amount,
+                data=dp.data,
+            )
+
+        # Replicate GroupDependency entries for the database parameter group
+        for gd in GroupDependency.select().where(GroupDependency.group == old_name):
+            GroupDependency.get_or_create(group=new_name, depends=gd.depends)
+
+        # Find activity parameter groups that belong to this database
+        old_aps = list(ActivityParameter.select().where(ActivityParameter.database == old_name))
+        if not old_aps:
+            return
+
+        old_groups = {ap.group for ap in old_aps}
+
+        # Groups are single-database; map old names to new unique names
+        group_mapping = {}
+        for g in old_groups:
+            candidate = f"{g}__{new_name}"
+            suffix = 0
+            while Group.get_or_none(Group.name == candidate) is not None:
+                suffix += 1
+                candidate = f"{g}__{new_name}_{suffix}"
+            group_mapping[g] = candidate
+
+        # Copy ActivityParameters into the new groups
+        for ap in old_aps:
+            ActivityParameter.create(
+                group=group_mapping[ap.group],
+                database=new_name,
+                code=ap.code,
+                name=ap.name,
+                formula=ap.formula,
+                amount=ap.amount,
+                data=ap.data,
+            )
+
+        # Copy group order, remapping group names that were also copied
+        for old_g, new_g in group_mapping.items():
+            old_group_obj = Group.get_or_none(Group.name == old_g)
+            if old_group_obj is not None and old_group_obj.order:
+                new_group_obj = Group.get(Group.name == new_g)
+                new_group_obj.order = [group_mapping.get(g, g) for g in old_group_obj.order]
+                new_group_obj.save()
+
+        # Replicate GroupDependency for activity parameter groups
+        for old_g, new_g in group_mapping.items():
+            for gd in GroupDependency.select().where(GroupDependency.group == old_g):
+                new_depends = group_mapping.get(gd.depends, gd.depends)
+                GroupDependency.get_or_create(group=new_g, depends=new_depends)
+
+        # Copy ParameterizedExchanges, mapping to new exchange IDs
+        for pe in ParameterizedExchange.select().where(ParameterizedExchange.group << old_groups):
+            old_exc = ExchangeDataset.get_or_none(ExchangeDataset.id == pe.exchange)
+            if old_exc is None:
+                continue
+
+            new_input_db = new_name if old_exc.input_database == old_name else old_exc.input_database
+            candidates = list(
+                ExchangeDataset.select().where(
+                    ExchangeDataset.output_database == new_name,
+                    ExchangeDataset.output_code == old_exc.output_code,
+                    ExchangeDataset.input_database == new_input_db,
+                    ExchangeDataset.input_code == old_exc.input_code,
+                    ExchangeDataset.type == old_exc.type,
+                )
+            )
+            if not candidates:
+                continue
+            if len(candidates) == 1:
+                new_exc = candidates[0]
+            else:
+                # Multiple exchanges with same endpoints — narrow by formula
+                formula_candidates = [c for c in candidates if c.data.get("formula") == pe.formula]
+                if len(formula_candidates) == 1:
+                    new_exc = formula_candidates[0]
+                else:
+                    continue
+
+            ParameterizedExchange.create(
+                group=group_mapping[pe.group],
+                exchange=new_exc.id,
+                formula=pe.formula,
+            )
 
     def copy_activities(
         self, activities: List[Activity], target_database: str, signal: bool = True

--- a/tests/database.py
+++ b/tests/database.py
@@ -128,6 +128,91 @@ def test_copy_does_deepcopy():
 
 
 @bw2test
+def test_copy_database_parameters():
+    data = {("db", "a"): {"exchanges": []}}
+    d = Database("db")
+    d.write(data)
+    DatabaseParameter.create(database="db", name="p1", amount=1.0)
+    DatabaseParameter.create(database="db", name="p2", formula="p1 * 2", amount=2.0)
+    d.copy("db_copy")
+    assert DatabaseParameter.select().where(DatabaseParameter.database == "db_copy").count() == 2
+    p = DatabaseParameter.get(DatabaseParameter.database == "db_copy", DatabaseParameter.name == "p2")
+    assert p.formula == "p1 * 2"
+    assert p.amount == 2.0
+
+
+@bw2test
+def test_copy_database_parameters_group_dependency():
+    from bw2data.parameters import GroupDependency, ProjectParameter
+
+    ProjectParameter.create(name="x", amount=5.0)
+    data = {("db", "a"): {"exchanges": []}}
+    d = Database("db")
+    d.write(data)
+    DatabaseParameter.create(database="db", name="p1", formula="x * 2", amount=10.0)
+    DatabaseParameter.recalculate("db")
+    assert GroupDependency.select().where(
+        GroupDependency.group == "db", GroupDependency.depends == "project"
+    ).count() == 1
+    d.copy("db_copy")
+    assert GroupDependency.select().where(
+        GroupDependency.group == "db_copy", GroupDependency.depends == "project"
+    ).count() == 1
+
+
+@bw2test
+def test_copy_activity_parameters():
+    from bw2data.parameters import Group
+
+    data = {("db", "act1"): {"exchanges": []}}
+    d = Database("db")
+    d.write(data)
+    ActivityParameter.create(group="grp", database="db", code="act1", name="ap1", amount=3.0)
+    d.copy("db_copy")
+
+    new_group = f"grp__db_copy"
+    assert ActivityParameter.select().where(
+        ActivityParameter.database == "db_copy"
+    ).count() == 1
+    ap = ActivityParameter.get(ActivityParameter.database == "db_copy")
+    assert ap.group == new_group
+    assert ap.code == "act1"
+    assert ap.name == "ap1"
+    assert ap.amount == 3.0
+    # Original untouched
+    assert ActivityParameter.select().where(ActivityParameter.database == "db").count() == 1
+
+
+@bw2test
+def test_copy_parameterized_exchanges():
+    data = {
+        ("db", "act1"): {
+            "exchanges": [{"input": ("db", "act1"), "amount": 1.0, "type": "production", "formula": "ap1 * 2"}]
+        }
+    }
+    d = Database("db")
+    d.write(data)
+    ActivityParameter.create(group="grp", database="db", code="act1", name="ap1", amount=3.0)
+    from bw2data.backends.schema import ExchangeDataset
+
+    exc = ExchangeDataset.get(
+        ExchangeDataset.output_database == "db",
+        ExchangeDataset.output_code == "act1",
+    )
+    ParameterizedExchange.create(group="grp", exchange=exc.id, formula="ap1 * 2")
+
+    d.copy("db_copy")
+
+    new_group = "grp__db_copy"
+    assert ParameterizedExchange.select().where(ParameterizedExchange.group == new_group).count() == 1
+    pe = ParameterizedExchange.get(ParameterizedExchange.group == new_group)
+    assert pe.formula == "ap1 * 2"
+    # Verify it points to the new database's exchange
+    new_exc = ExchangeDataset.get(ExchangeDataset.id == pe.exchange)
+    assert new_exc.output_database == "db_copy"
+
+
+@bw2test
 def test_raise_wrong_database():
     data = {("foo", "1"): {}}
     d = Database("bar")


### PR DESCRIPTION
## Summary

- `Database.copy()` now copies `DatabaseParameter`, `ActivityParameter`, and `ParameterizedExchange` records to the new database
- `DatabaseParameter` records are straightforward: copied with `database = new_name`, preserving name/formula/amount/data
- `ActivityParameter` groups are single-database (enforced by a cross-database SQLite trigger), so copied groups get new names of the form `{old_group}__{new_name}`; `GroupDependency` and group order are replicated with the name mapping applied
- `ParameterizedExchange` records are matched to their new exchange by `(output_code, input_code, input_database, type)`, with formula as a tiebreaker if multiple candidates exist

## Test plan

- [ ] `test_copy_database_parameters` — verifies DatabaseParameter records are copied with correct name/formula/amount
- [ ] `test_copy_database_parameters_group_dependency` — verifies `GroupDependency(depends="project")` is replicated for the new database group
- [ ] `test_copy_activity_parameters` — verifies ActivityParameter records are copied to a new group `{old_group}__{new_name}`, original untouched
- [ ] `test_copy_parameterized_exchanges` — verifies ParameterizedExchange is copied with correct formula and points to the new database's exchange
- [ ] Existing `test_copy`, `test_copy_metadata`, `test_copy_does_deepcopy` still pass