### PR TITLE
Migrate databases.json metadata to SQLite

### DIFF
--- a/bw2data/backends/__init__.py
+++ b/bw2data/backends/__init__.py
@@ -3,11 +3,11 @@ import os
 from bw2data import config
 from bw2data.project import projects
 from bw2data.sqlite import SubstitutableDatabase
-from bw2data.backends.schema import ActivityDataset, DatabaseMetadata, ExchangeDataset, get_id
+from bw2data.backends.schema import ActivityDataset, DatabaseRecord, ExchangeDataset, get_id
 
 sqlite3_lci_db = SubstitutableDatabase(
     projects.dir / "lci" / "databases.db",
-    [ActivityDataset, ExchangeDataset, DatabaseMetadata],
+    [ActivityDataset, ExchangeDataset, DatabaseRecord],
 )
 
 from bw2data.backends.base import SQLiteBackend

--- a/bw2data/backends/__init__.py
+++ b/bw2data/backends/__init__.py
@@ -3,11 +3,11 @@ import os
 from bw2data import config
 from bw2data.project import projects
 from bw2data.sqlite import SubstitutableDatabase
-from bw2data.backends.schema import ActivityDataset, ExchangeDataset, get_id
+from bw2data.backends.schema import ActivityDataset, DatabaseMetadata, ExchangeDataset, get_id
 
 sqlite3_lci_db = SubstitutableDatabase(
     projects.dir / "lci" / "databases.db",
-    [ActivityDataset, ExchangeDataset],
+    [ActivityDataset, ExchangeDataset, DatabaseMetadata],
 )
 
 from bw2data.backends.base import SQLiteBackend

--- a/bw2data/backends/base.py
+++ b/bw2data/backends/base.py
@@ -229,7 +229,7 @@ class SQLiteBackend(ProcessedDataStore):
         with warnings.catch_warnings():
             warnings.simplefilter("ignore")
             new_database = self.__class__(name)
-            metadata = copy.copy(self.metadata)
+            metadata = dict(self.metadata)
             metadata["format"] = f"Copied from '{self.name}'"
             new_database.register(**metadata)
 
@@ -985,14 +985,20 @@ Here are the type values usually used for nodes:
         if self._searchable and not reset:
             stdout_feedback_logger.info("This database is already searchable")
             return
-        databases[self.name]["searchable"] = True
-        databases.flush(signal=signal)
+        databases._suppress_signals = not signal
+        try:
+            databases[self.name]["searchable"] = True
+        finally:
+            databases._suppress_signals = False
         IndexManager(self.filename).create()
         IndexManager(self.filename).add_datasets(self)
 
     def make_unsearchable(self, signal: bool = True):
-        databases[self.name]["searchable"] = False
-        databases.flush(signal=signal)
+        databases._suppress_signals = not signal
+        try:
+            databases[self.name]["searchable"] = False
+        finally:
+            databases._suppress_signals = False
         IndexManager(self.filename).delete_database()
 
     def delete(
@@ -1217,7 +1223,6 @@ Here are the type values usually used for nodes:
 
         self.metadata["depends"] = sorted(dependents)
         self.metadata["dirty"] = False
-        self._metadata.flush()
 
     def search(self, string, **kwargs):
         """Search this database for ``string``.
@@ -1270,7 +1275,6 @@ Here are the type values usually used for nodes:
             geocollections.discard(None)
         else:
             self.metadata["geocollections"] = sorted(geocollections)
-            self._metadata.flush()
 
     def graph_technosphere(self, filename=None, **kwargs):
         from bw2analyzer.matrix_grapher import SparseMatrixGrapher

--- a/bw2data/backends/iotable/backend.py
+++ b/bw2data/backends/iotable/backend.py
@@ -104,7 +104,6 @@ class IOTableBackend(SQLiteBackend):
 
         databases[self.name]["depends"] = sorted(set(dependents).difference({self.name}))
         databases[self.name]["processed"] = datetime.datetime.now().isoformat()
-        databases.flush()
 
     def process(self):
         """No-op; no intermediate data to process"""

--- a/bw2data/backends/schema.py
+++ b/bw2data/backends/schema.py
@@ -1,4 +1,4 @@
-from peewee import DoesNotExist, TextField
+from peewee import BooleanField, DoesNotExist, IntegerField, Model, TextField
 
 from bw2data.errors import UnknownObject
 from bw2data.signals import (
@@ -11,7 +11,7 @@ from bw2data.signals import (
     signaleddataset_on_delete,
 )
 from bw2data.snowflake_ids import SnowflakeIDBaseClass
-from bw2data.sqlite import PickleField
+from bw2data.sqlite import JSONField, PickleField
 
 
 class ActivityDataset(SnowflakeIDBaseClass):
@@ -35,6 +35,26 @@ class ExchangeDataset(SnowflakeIDBaseClass):
     output_code = TextField()  # Canonical
     output_database = TextField()  # Canonical
     type = TextField()  # Reset from `data`
+
+
+class DatabaseMetadata(Model):
+    """Metadata for a registered LCI database. Stored in the per-project `lci/databases.db`.
+
+    All columns are nullable. A ``NULL`` value means the field was never explicitly set,
+    which matches the historical behaviour of ``databases.json`` where absent keys were
+    simply not present in the dict.
+    """
+
+    name = TextField(primary_key=True)
+    backend = TextField(null=True)
+    depends = JSONField(null=True)
+    dirty = BooleanField(null=True)
+    version = IntegerField(null=True)
+    modified = TextField(null=True)       # ISO timestamp string
+    number = IntegerField(null=True)
+    searchable = BooleanField(null=True)
+    geocollections = JSONField(null=True)
+    extra = JSONField(null=True)          # arbitrary user-defined fields
 
 
 _get_id_cache: dict = {}

--- a/bw2data/backends/schema.py
+++ b/bw2data/backends/schema.py
@@ -37,8 +37,8 @@ class ExchangeDataset(SnowflakeIDBaseClass):
     type = TextField()  # Reset from `data`
 
 
-class DatabaseMetadata(Model):
-    """Metadata for a registered LCI database. Stored in the per-project `lci/databases.db`.
+class DatabaseRecord(Model):
+    """Registry record for a registered LCI database. Stored in the per-project `lci/databases.db`.
 
     All columns are nullable. A ``NULL`` value means the field was never explicitly set,
     which matches the historical behaviour of ``databases.json`` where absent keys were

--- a/bw2data/data_store.py
+++ b/bw2data/data_store.py
@@ -44,7 +44,6 @@ class DataStore:
     def _set_metadata(self, value):
         self._get_metadata()
         self._metadata[self.name] = value
-        self._metadata.flush()
 
     metadata = property(_get_metadata, _set_metadata)
 

--- a/bw2data/meta.py
+++ b/bw2data/meta.py
@@ -70,8 +70,8 @@ class GeoMapping(PickledDict):
         return len(self.data)
 
 
-class DatabaseMetadataProxy(MutableMapping):
-    """Dict-like view of a single :class:`~bw2data.backends.schema.DatabaseMetadata` row.
+class DatabaseRecordProxy(MutableMapping):
+    """Dict-like view of a single :class:`~bw2data.backends.schema.DatabaseRecord` row.
 
     Writes are immediately persisted to SQLite. Signals are NOT emitted by this
     class — callers that need to signal a change should call
@@ -152,7 +152,7 @@ class DatabaseMetadataProxy(MutableMapping):
 
 
 class Databases(MutableMapping):
-    """Dict-like registry of database metadata, backed by the ``DatabaseMetadata`` SQLite table
+    """Dict-like registry of database metadata, backed by the ``DatabaseRecord`` SQLite table
     in the per-project ``lci/databases.db``.
 
     Previously stored in ``databases.json``; the file is migrated automatically on first access.
@@ -170,24 +170,24 @@ class Databases(MutableMapping):
 
     def __getitem__(self, name):
         self._ensure_migrated()
-        from bw2data.backends.schema import DatabaseMetadata
+        from bw2data.backends.schema import DatabaseRecord
         from peewee import DoesNotExist
 
         try:
-            return DatabaseMetadataProxy(
-                DatabaseMetadata.get(DatabaseMetadata.name == name), self
+            return DatabaseRecordProxy(
+                DatabaseRecord.get(DatabaseRecord.name == name), self
             )
         except DoesNotExist:
             raise KeyError(name)
 
     def __setitem__(self, name, value):
         self._ensure_migrated()
-        from bw2data.backends.schema import DatabaseMetadata
+        from bw2data.backends.schema import DatabaseRecord
 
         old = self._as_dict()
         value = dict(value)  # copy to avoid mutating caller's dict
         known = {k: value.pop(k) for k in list(value) if k in _KNOWN_FIELDS}
-        DatabaseMetadata.replace(name=name, extra=value or None, **known).execute()
+        DatabaseRecord.replace(name=name, extra=value or None, **known).execute()
         self._emit(old)
 
     def __delitem__(self, name: str, signal: bool = True):
@@ -207,30 +207,30 @@ Metadata state is unchanged, but database state is unknown.
             )
             return
 
-        from bw2data.backends.schema import DatabaseMetadata
+        from bw2data.backends.schema import DatabaseRecord
 
-        DatabaseMetadata.delete().where(DatabaseMetadata.name == name).execute()
+        DatabaseRecord.delete().where(DatabaseRecord.name == name).execute()
 
         if signal:
             on_database_delete.send(self, name=name)
 
     def __iter__(self):
         self._ensure_migrated()
-        from bw2data.backends.schema import DatabaseMetadata
+        from bw2data.backends.schema import DatabaseRecord
 
-        return (row.name for row in DatabaseMetadata.select(DatabaseMetadata.name))
+        return (row.name for row in DatabaseRecord.select(DatabaseRecord.name))
 
     def __len__(self):
         self._ensure_migrated()
-        from bw2data.backends.schema import DatabaseMetadata
+        from bw2data.backends.schema import DatabaseRecord
 
-        return DatabaseMetadata.select().count()
+        return DatabaseRecord.select().count()
 
     def __contains__(self, name):
         self._ensure_migrated()
-        from bw2data.backends.schema import DatabaseMetadata
+        from bw2data.backends.schema import DatabaseRecord
 
-        return DatabaseMetadata.select().where(DatabaseMetadata.name == name).exists()
+        return DatabaseRecord.select().where(DatabaseRecord.name == name).exists()
 
     def __str__(self):
         names = list(self)
@@ -259,9 +259,9 @@ Metadata state is unchanged, but database state is unknown.
 
     def increment_version(self, database, number=None):
         """Increment the ``database`` version. Returns the new version."""
-        from bw2data.backends.schema import DatabaseMetadata
+        from bw2data.backends.schema import DatabaseRecord
 
-        row = DatabaseMetadata.get(DatabaseMetadata.name == database)
+        row = DatabaseRecord.get(DatabaseRecord.name == database)
         row.version = (row.version or 0) + 1
         if number is not None:
             row.number = number
@@ -270,21 +270,21 @@ Metadata state is unchanged, but database state is unknown.
 
     def version(self, database):
         """Return the ``database`` version."""
-        from bw2data.backends.schema import DatabaseMetadata
+        from bw2data.backends.schema import DatabaseRecord
 
-        return DatabaseMetadata.get(DatabaseMetadata.name == database).version
+        return DatabaseRecord.get(DatabaseRecord.name == database).version
 
     def set_modified(self, database):
-        from bw2data.backends.schema import DatabaseMetadata
+        from bw2data.backends.schema import DatabaseRecord
 
-        row = DatabaseMetadata.get(DatabaseMetadata.name == database)
+        row = DatabaseRecord.get(DatabaseRecord.name == database)
         row.modified = datetime.datetime.now().isoformat()
         row.save()
 
     def set_dirty(self, database):
-        from bw2data.backends.schema import DatabaseMetadata
+        from bw2data.backends.schema import DatabaseRecord
 
-        row = DatabaseMetadata.get(DatabaseMetadata.name == database)
+        row = DatabaseRecord.get(DatabaseRecord.name == database)
         row.modified = datetime.datetime.now().isoformat()
         if not row.dirty:
             row.dirty = True
@@ -292,16 +292,16 @@ Metadata state is unchanged, but database state is unknown.
 
     def clean(self):
         from bw2data import Database
-        from bw2data.backends.schema import DatabaseMetadata
+        from bw2data.backends.schema import DatabaseRecord
 
         dirty = [
-            r.name for r in DatabaseMetadata.select().where(DatabaseMetadata.dirty == True)
+            r.name for r in DatabaseRecord.select().where(DatabaseRecord.dirty == True)
         ]
         if not dirty:
             return
         for name in dirty:
             Database(name).process()
-        DatabaseMetadata.update(dirty=None).where(DatabaseMetadata.name << dirty).execute()
+        DatabaseRecord.update(dirty=None).where(DatabaseRecord.name << dirty).execute()
 
     @property
     def list(self):
@@ -347,13 +347,13 @@ Metadata state is unchanged, but database state is unknown.
     @data.setter
     def data(self, new_data):
         """Replace all metadata rows. Used by the revision system to replay patches."""
-        from bw2data.backends.schema import DatabaseMetadata
+        from bw2data.backends.schema import DatabaseRecord
 
-        DatabaseMetadata.delete().execute()
+        DatabaseRecord.delete().execute()
         for name, meta in new_data.items():
             meta = dict(meta)
             known = {k: meta.pop(k) for k in list(meta) if k in _KNOWN_FIELDS}
-            DatabaseMetadata.replace(name=name, extra=meta or None, **known).execute()
+            DatabaseRecord.replace(name=name, extra=meta or None, **known).execute()
 
     def _ensure_migrated(self):
         if not self._migrated:
@@ -363,13 +363,13 @@ Metadata state is unchanged, but database state is unknown.
     def _migrate_from_json(self):
         """One-time migration from ``databases.json`` to SQLite on first access."""
         from bw2data.project import projects
-        from bw2data.backends.schema import DatabaseMetadata
+        from bw2data.backends.schema import DatabaseRecord
         import json
 
         json_path = projects.dir / "databases.json"
         if not json_path.exists():
             return
-        if DatabaseMetadata.select().count() > 0:
+        if DatabaseRecord.select().count() > 0:
             return
 
         warnings.warn(
@@ -383,7 +383,7 @@ Metadata state is unchanged, but database state is unknown.
         for name, meta in data.items():
             meta = dict(meta)
             known = {k: meta.pop(k) for k in list(meta) if k in _KNOWN_FIELDS}
-            DatabaseMetadata.replace(name=name, extra=meta or None, **known).execute()
+            DatabaseRecord.replace(name=name, extra=meta or None, **known).execute()
 
 
 class CalculationSetups(PickledDict):

--- a/bw2data/meta.py
+++ b/bw2data/meta.py
@@ -1,10 +1,23 @@
 import datetime
 import warnings
-from pathlib import Path
-from typing import Union
+from collections.abc import MutableMapping
 
-from bw2data.serialization import CompoundJSONDict, PickledDict, SerializedDict
+from bw2data.serialization import CompoundJSONDict, PickledDict
 from bw2data.signals import on_database_delete, on_database_metadata_change
+
+
+_KNOWN_FIELDS = frozenset(
+    {
+        "backend",
+        "depends",
+        "dirty",
+        "geocollections",
+        "modified",
+        "number",
+        "searchable",
+        "version",
+    }
+)
 
 
 class GeoMapping(PickledDict):
@@ -57,60 +70,135 @@ class GeoMapping(PickledDict):
         return len(self.data)
 
 
-class Databases(SerializedDict):
-    """A dictionary for database metadata. This class includes methods to manage database versions. File data is saved in ``databases.json``."""
+class DatabaseMetadataProxy(MutableMapping):
+    """Dict-like view of a single :class:`~bw2data.backends.schema.DatabaseMetadata` row.
 
-    filename = "databases.json"
+    Writes are immediately persisted to SQLite. Signals are NOT emitted by this
+    class — callers that need to signal a change should call
+    ``databases._emit(old_state)`` explicitly after mutating the proxy.
+    """
+
+    def __init__(self, row, parent):
+        self._row = row
+        self._parent = parent
+
+    def _all_fields(self):
+        """Return only the fields that have been explicitly set (non-NULL)."""
+        d = {f: getattr(self._row, f) for f in _KNOWN_FIELDS if getattr(self._row, f) is not None}
+        d.update(self._row.extra or {})
+        return d
+
+    def __getitem__(self, key):
+        if key in _KNOWN_FIELDS:
+            val = getattr(self._row, key)
+            if val is None:
+                raise KeyError(key)
+            return val
+        extra = self._row.extra or {}
+        if key in extra:
+            return extra[key]
+        raise KeyError(key)
+
+    def __setitem__(self, key, value):
+        suppress = self._parent._suppress_signals
+        old = None if suppress else self._parent._as_dict()
+        if key in _KNOWN_FIELDS:
+            setattr(self._row, key, value)
+        else:
+            extra = dict(self._row.extra or {})
+            extra[key] = value
+            self._row.extra = extra
+        self._row.save()
+        if not suppress:
+            self._parent._emit(old)
+
+    def __delitem__(self, key):
+        suppress = self._parent._suppress_signals
+        old = None if suppress else self._parent._as_dict()
+        if key in _KNOWN_FIELDS:
+            setattr(self._row, key, None)
+        else:
+            extra = dict(self._row.extra or {})
+            if key not in extra:
+                raise KeyError(key)
+            del extra[key]
+            self._row.extra = extra
+        self._row.save()
+        if not suppress:
+            self._parent._emit(old)
+
+    def __iter__(self):
+        return iter(self._all_fields())
+
+    def __len__(self):
+        return len(self._all_fields())
+
+    def __contains__(self, key):
+        if key in _KNOWN_FIELDS:
+            return getattr(self._row, key) is not None
+        return key in (self._row.extra or {})
+
+    def get(self, key, default=None):
+        try:
+            return self[key]
+        except KeyError:
+            return default
+
+    def __copy__(self):
+        return dict(self)
+
+    def __repr__(self):
+        return repr(dict(self))
+
+
+class Databases(MutableMapping):
+    """Dict-like registry of database metadata, backed by the ``DatabaseMetadata`` SQLite table
+    in the per-project ``lci/databases.db``.
+
+    Previously stored in ``databases.json``; the file is migrated automatically on first access.
+    """
+
     _save_signal = on_database_metadata_change
 
-    def increment_version(self, database, number=None):
-        """Increment the ``database`` version. Returns the new version."""
-        self.data[database]["version"] += 1
-        if number is not None:
-            self.data[database]["number"] = number
-        self.flush()
-        return self.data[database]["version"]
+    def __init__(self):
+        self._migrated = False
+        self._suppress_signals = False
 
-    def version(self, database):
-        """Return the ``database`` version"""
-        return self.data[database].get("version")
+    # ------------------------------------------------------------------
+    # MutableMapping interface
+    # ------------------------------------------------------------------
 
-    def set_modified(self, database):
-        self[database]["modified"] = datetime.datetime.now().isoformat()
-        self.flush()
+    def __getitem__(self, name):
+        self._ensure_migrated()
+        from bw2data.backends.schema import DatabaseMetadata
+        from peewee import DoesNotExist
 
-    def set_dirty(self, database):
-        self.set_modified(database)
-        if self[database].get("dirty"):
-            pass
-        else:
-            self[database]["dirty"] = True
-            self.flush()
+        try:
+            return DatabaseMetadataProxy(
+                DatabaseMetadata.get(DatabaseMetadata.name == name), self
+            )
+        except DoesNotExist:
+            raise KeyError(name)
 
-    def clean(self):
-        from bw2data import Database
+    def __setitem__(self, name, value):
+        self._ensure_migrated()
+        from bw2data.backends.schema import DatabaseMetadata
 
-        def _clean():
-            for x in self:
-                if self[x].get("dirty"):
-                    Database(x).process()
-                    del self[x]["dirty"]
-            self.flush()
-
-        if not any(self[x].get("dirty") for x in self):
-            return
-        else:
-            return _clean()
+        old = self._as_dict()
+        value = dict(value)  # copy to avoid mutating caller's dict
+        known = {k: value.pop(k) for k in list(value) if k in _KNOWN_FIELDS}
+        DatabaseMetadata.replace(name=name, extra=value or None, **known).execute()
+        self._emit(old)
 
     def __delitem__(self, name: str, signal: bool = True):
         from bw2data import Database
 
         if name not in self:
-            raise KeyError
+            raise KeyError(name)
 
         try:
             Database(name).delete(warn=False, signal=False)
-        except:
+        except Exception:
             warnings.warn(
                 """
 Deletion unsuccessful due to database error.
@@ -119,10 +207,183 @@ Metadata state is unchanged, but database state is unknown.
             )
             return
 
-        super(Databases, self).__delitem__(name=name, signal=False)
+        from bw2data.backends.schema import DatabaseMetadata
+
+        DatabaseMetadata.delete().where(DatabaseMetadata.name == name).execute()
 
         if signal:
             on_database_delete.send(self, name=name)
+
+    def __iter__(self):
+        self._ensure_migrated()
+        from bw2data.backends.schema import DatabaseMetadata
+
+        return (row.name for row in DatabaseMetadata.select(DatabaseMetadata.name))
+
+    def __len__(self):
+        self._ensure_migrated()
+        from bw2data.backends.schema import DatabaseMetadata
+
+        return DatabaseMetadata.select().count()
+
+    def __contains__(self, name):
+        self._ensure_migrated()
+        from bw2data.backends.schema import DatabaseMetadata
+
+        return DatabaseMetadata.select().where(DatabaseMetadata.name == name).exists()
+
+    def __str__(self):
+        names = list(self)
+        if not names:
+            return "Databases dictionary with 0 objects"
+        elif len(names) > 20:
+            return (
+                "Databases dictionary with {} objects, including:"
+                "{}\nUse `list(this object)` to get the complete list."
+            ).format(
+                len(names),
+                "".join(["\n\t{}".format(x) for x in sorted(names)[:10]]),
+            )
+        else:
+            return ("Databases dictionary with {} object(s):{}").format(
+                len(names),
+                "".join(["\n\t{}".format(x) for x in sorted(names)]),
+            )
+
+    def __repr__(self):
+        return str(self)
+
+    # ------------------------------------------------------------------
+    # Domain methods
+    # ------------------------------------------------------------------
+
+    def increment_version(self, database, number=None):
+        """Increment the ``database`` version. Returns the new version."""
+        from bw2data.backends.schema import DatabaseMetadata
+
+        row = DatabaseMetadata.get(DatabaseMetadata.name == database)
+        row.version = (row.version or 0) + 1
+        if number is not None:
+            row.number = number
+        row.save()
+        return row.version
+
+    def version(self, database):
+        """Return the ``database`` version."""
+        from bw2data.backends.schema import DatabaseMetadata
+
+        return DatabaseMetadata.get(DatabaseMetadata.name == database).version
+
+    def set_modified(self, database):
+        from bw2data.backends.schema import DatabaseMetadata
+
+        row = DatabaseMetadata.get(DatabaseMetadata.name == database)
+        row.modified = datetime.datetime.now().isoformat()
+        row.save()
+
+    def set_dirty(self, database):
+        from bw2data.backends.schema import DatabaseMetadata
+
+        row = DatabaseMetadata.get(DatabaseMetadata.name == database)
+        row.modified = datetime.datetime.now().isoformat()
+        if not row.dirty:
+            row.dirty = True
+        row.save()
+
+    def clean(self):
+        from bw2data import Database
+        from bw2data.backends.schema import DatabaseMetadata
+
+        dirty = [
+            r.name for r in DatabaseMetadata.select().where(DatabaseMetadata.dirty == True)
+        ]
+        if not dirty:
+            return
+        for name in dirty:
+            Database(name).process()
+        DatabaseMetadata.update(dirty=None).where(DatabaseMetadata.name << dirty).execute()
+
+    @property
+    def list(self):
+        """List the keys of the dictionary."""
+        return sorted(self)
+
+    def random(self):
+        """Return a random database name, or ``None`` if empty."""
+        import random as _random
+
+        names = list(self)
+        return _random.choice(names) if names else None
+
+    # ------------------------------------------------------------------
+    # Deprecated shims
+    # ------------------------------------------------------------------
+
+    def flush(self, signal: bool = True):
+        """Deprecated no-op. Data is auto-persisted to SQLite and signals fire on each write."""
+        warnings.warn(
+            "Databases.flush() is deprecated; metadata is now auto-persisted to SQLite.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+
+    def _emit(self, old):
+        """Emit on_database_metadata_change with the given old state and current new state."""
+        on_database_metadata_change.send(self, old=old, new=self._as_dict())
+
+    def _as_dict(self):
+        """Reconstruct a plain dict of all metadata (used for signal old/new payloads)."""
+        return {name: dict(self[name]) for name in self}
+
+    @property
+    def data(self):
+        """Return the full metadata as a plain dict. Used by the revision system."""
+        return self._as_dict()
+
+    @data.setter
+    def data(self, new_data):
+        """Replace all metadata rows. Used by the revision system to replay patches."""
+        from bw2data.backends.schema import DatabaseMetadata
+
+        DatabaseMetadata.delete().execute()
+        for name, meta in new_data.items():
+            meta = dict(meta)
+            known = {k: meta.pop(k) for k in list(meta) if k in _KNOWN_FIELDS}
+            DatabaseMetadata.replace(name=name, extra=meta or None, **known).execute()
+
+    def _ensure_migrated(self):
+        if not self._migrated:
+            self._migrated = True
+            self._migrate_from_json()
+
+    def _migrate_from_json(self):
+        """One-time migration from ``databases.json`` to SQLite on first access."""
+        from bw2data.project import projects
+        from bw2data.backends.schema import DatabaseMetadata
+        import json
+
+        json_path = projects.dir / "databases.json"
+        if not json_path.exists():
+            return
+        if DatabaseMetadata.select().count() > 0:
+            return
+
+        warnings.warn(
+            f"Migrating {json_path} to SQLite (one-time operation). "
+            "The original file is kept as a backup.",
+            stacklevel=2,
+        )
+        with open(json_path, encoding="utf-8") as f:
+            data = json.load(f)
+
+        for name, meta in data.items():
+            meta = dict(meta)
+            known = {k: meta.pop(k) for k in list(meta) if k in _KNOWN_FIELDS}
+            DatabaseMetadata.replace(name=name, extra=meta or None, **known).execute()
 
 
 class CalculationSetups(PickledDict):

--- a/bw2data/revisions.py
+++ b/bw2data/revisions.py
@@ -253,7 +253,7 @@ class Delta:
             # (i.e. changing the graph will set database['dirty']) or are not worth propagating
             # so we can safely remove them from the diff generation.
             for value in dct.values():
-                for forgotten in ("processed", "modified", "dirty", "number"):
+                for forgotten in ("processed", "modified", "dirty", "number", "version"):
                     if forgotten in value:
                         del value[forgotten]
         diff = deepdiff.DeepDiff(
@@ -588,7 +588,6 @@ class RevisionedDatabase:
                 elif not value.get("searchable") and databases.get(name, {}).get("searchable"):
                     DatabaseChooser(name).make_unsearchable(reset=False, signal=False)
             databases.data = new_data
-            databases.flush(signal=False)
         if revision_data["change_type"] == "database_reset":
             DatabaseChooser(revision_data["id"]).delete(warn=False, signal=False)
         if revision_data["change_type"] == "database_delete":

--- a/bw2data/signals.py
+++ b/bw2data/signals.py
@@ -56,11 +56,11 @@ No expected return value.
 
 on_database_metadata_change = signal(
     "bw2data.on_database_metadata_change",
-    doc="""Emitted *after* any element of `databases.json` has changed.
+    doc="""Emitted *after* any database metadata has changed.
 
 Expected inputs:
-    * `old`: dict - previous `databases.json` metadata dict
-    * `new`: dict - current `databases.json` metadata dict
+    * `old`: dict - previous full database metadata dict (all databases)
+    * `new`: dict - current full database metadata dict (all databases)
 
 No expected return value.
 """,

--- a/bw2data/sqlite.py
+++ b/bw2data/sqlite.py
@@ -59,6 +59,8 @@ class JSONField(TextField):
     """Simpler JSON field that doesn't support advanced querying and is human-readable"""
 
     def db_value(self, value):
+        if value is None:
+            return None
         return super().db_value(
             json.dumps(
                 value,
@@ -69,6 +71,8 @@ class JSONField(TextField):
         )
 
     def python_value(self, value):
+        if value is None:
+            return None
         return json.loads(value)
 
 

--- a/tests/projects.py
+++ b/tests/projects.py
@@ -280,7 +280,7 @@ def test_set_readonly_project_first_time():
 
 @bw2test
 def test_set_current_reset_metadata():
-    databases["foo"] = "bar"
+    databases["foo"] = {"backend": "sqlite", "depends": []}
     assert "foo" in databases
     projects.set_current("foo")
     assert "foo" not in databases
@@ -331,7 +331,7 @@ def test_copy_project():
     ds.data["this"] = "that"
     ds.save()
 
-    databases["foo"] = "bar"
+    databases["foo"] = {"backend": "sqlite", "depends": []}
     projects.copy_project("another one", False)
     assert "another one" in projects
 
@@ -339,7 +339,8 @@ def test_copy_project():
     assert ds.data["this"] == "that"
 
     projects.set_current("another one")
-    assert databases["foo"] == "bar"
+    assert "foo" in databases
+    assert databases["foo"]["backend"] == "sqlite"
 
 
 @bw2test

--- a/tests/unit/test_database_events.py
+++ b/tests/unit/test_database_events.py
@@ -20,35 +20,41 @@ def test_database_metadata_revision_expected_format_update():
     projects.dataset.set_sourced()
     assert projects.dataset.revision is None
 
+    # Each proxy write immediately persists and emits a signal, creating one revision per change.
+    r1 = projects.dataset.revision
     database.metadata["foo"] = True
-    database.metadata["other"] = 7
-    databases.flush()
+    r2 = projects.dataset.revision
+    assert r2 is not None and r2 != r1
 
-    assert projects.dataset.revision is not None
-    with open(projects.dataset.dir / "revisions" / f"{projects.dataset.revision}.rev", "r") as f:
+    database.metadata["other"] = 7
+    r3 = projects.dataset.revision
+    assert r3 is not None and r3 != r2
+
+    # Verify the most recent revision contains only the last change.
+    with open(projects.dataset.dir / "revisions" / f"{r3}.rev", "r") as f:
         revision = json.load(f)
 
-    expected = {
-        "metadata": {
-            "parent_revision": None,
-            "revision": projects.dataset.revision,
-            "authors": "Anonymous",
-            "title": "Untitled revision",
-            "description": "No description",
-        },
-        "data": [
-            {
-                "type": "lci_database",
-                "id": None,
-                "change_type": "database_metadata_change",
-                "delta": {
-                    "dictionary_item_added": {"root['db']['foo']": True, "root['db']['other']": 7}
-                },
-            }
-        ],
-    }
+    assert revision["data"] == [
+        {
+            "type": "lci_database",
+            "id": None,
+            "change_type": "database_metadata_change",
+            "delta": {"dictionary_item_added": {"root['db']['other']": 7}},
+        }
+    ]
 
-    assert revision == expected
+    # Verify the prior revision contains the first change.
+    with open(projects.dataset.dir / "revisions" / f"{r2}.rev", "r") as f:
+        revision_1 = json.load(f)
+
+    assert revision_1["data"] == [
+        {
+            "type": "lci_database",
+            "id": None,
+            "change_type": "database_metadata_change",
+            "delta": {"dictionary_item_added": {"root['db']['foo']": True}},
+        }
+    ]
 
 
 @bw2test
@@ -451,10 +457,33 @@ def test_database_write_revision_expected_format():
                 }
             ],
         },
+        # With immediate signal emission, geocollections is set during write() before the
+        # data is committed, creating its own revision.
         {
             "metadata": {
                 "parent_revision": revisions[0][0],
                 "revision": revisions[1][0],
+                "authors": "Anonymous",
+                "title": "Untitled revision",
+                "description": "No description",
+            },
+            "data": [
+                {
+                    "type": "lci_database",
+                    "id": None,
+                    "change_type": "database_metadata_change",
+                    "delta": {
+                        "dictionary_item_added": {
+                            "root['food']['geocollections']": ["world"],
+                        }
+                    },
+                }
+            ],
+        },
+        {
+            "metadata": {
+                "parent_revision": revisions[1][0],
+                "revision": revisions[2][0],
                 "authors": "Anonymous",
                 "title": "Untitled revision",
                 "description": "No description",
@@ -470,8 +499,8 @@ def test_database_write_revision_expected_format():
         },
         {
             "metadata": {
-                "parent_revision": revisions[1][0],
-                "revision": revisions[2][0],
+                "parent_revision": revisions[2][0],
+                "revision": revisions[3][0],
                 "authors": "Anonymous",
                 "title": "Untitled revision",
                 "description": "No description",
@@ -487,8 +516,8 @@ def test_database_write_revision_expected_format():
         },
         {
             "metadata": {
-                "parent_revision": revisions[2][0],
-                "revision": revisions[3][0],
+                "parent_revision": revisions[3][0],
+                "revision": revisions[4][0],
                 "authors": "Anonymous",
                 "title": "Untitled revision",
                 "description": "No description",
@@ -671,7 +700,7 @@ def test_database_write_revision_expected_format():
     ]
 
     assert [x[1] for x in revisions] == expected
-    assert projects.dataset.revision == revisions[3][0]
+    assert projects.dataset.revision == revisions[4][0]
 
 
 @bw2test
@@ -1015,6 +1044,8 @@ def test_database_copy_revision_expected_format():
                 }
             ],
         },
+        # With immediate signal emission, geocollections and depends are cleared
+        # in separate revisions when write_empty=True writes an empty database first.
         {
             "metadata": {
                 "parent_revision": revisions[0][0],
@@ -1030,7 +1061,6 @@ def test_database_copy_revision_expected_format():
                     "change_type": "database_metadata_change",
                     "delta": {
                         "iterable_item_removed": {
-                            "root['yum']['depends'][0]": "biosphere",
                             "root['yum']['geocollections'][0]": "world",
                         }
                     },
@@ -1048,9 +1078,13 @@ def test_database_copy_revision_expected_format():
             "data": [
                 {
                     "type": "lci_database",
-                    "id": "yum",
-                    "change_type": "database_reset",
-                    "delta": {},
+                    "id": None,
+                    "change_type": "database_metadata_change",
+                    "delta": {
+                        "iterable_item_removed": {
+                            "root['yum']['depends'][0]": "biosphere",
+                        }
+                    },
                 }
             ],
         },
@@ -1067,7 +1101,11 @@ def test_database_copy_revision_expected_format():
                     "type": "lci_database",
                     "id": None,
                     "change_type": "database_metadata_change",
-                    "delta": {"iterable_item_added": {"root['yum']['depends'][0]": "biosphere"}},
+                    "delta": {
+                        "iterable_item_added": {
+                            "root['yum']['geocollections'][0]": "world",
+                        }
+                    },
                 }
             ],
         },
@@ -1075,6 +1113,40 @@ def test_database_copy_revision_expected_format():
             "metadata": {
                 "parent_revision": revisions[3][0],
                 "revision": revisions[4][0],
+                "authors": "Anonymous",
+                "title": "Untitled revision",
+                "description": "No description",
+            },
+            "data": [
+                {
+                    "type": "lci_database",
+                    "id": "yum",
+                    "change_type": "database_reset",
+                    "delta": {},
+                }
+            ],
+        },
+        {
+            "metadata": {
+                "parent_revision": revisions[4][0],
+                "revision": revisions[5][0],
+                "authors": "Anonymous",
+                "title": "Untitled revision",
+                "description": "No description",
+            },
+            "data": [
+                {
+                    "type": "lci_database",
+                    "id": None,
+                    "change_type": "database_metadata_change",
+                    "delta": {"iterable_item_added": {"root['yum']['depends'][0]": "biosphere"}},
+                }
+            ],
+        },
+        {
+            "metadata": {
+                "parent_revision": revisions[5][0],
+                "revision": revisions[6][0],
                 "authors": "Anonymous",
                 "title": "Untitled revision",
                 "description": "No description",
@@ -1262,7 +1334,7 @@ def test_database_copy_revision_expected_format():
         assert revisions[-1][1]["data"][x] in expected[-1]["data"][:2]
     for x in range(2, 5):
         assert revisions[-1][1]["data"][x] in expected[-1]["data"][2:]
-    assert projects.dataset.revision == revisions[4][0]
+    assert projects.dataset.revision == revisions[6][0]
 
 
 @bw2test


### PR DESCRIPTION
## Summary

- Replaces the per-project `databases.json` file with a `DatabaseRecord` Peewee model stored in the existing `lci/databases.db`
- The old dict-like `databases["name"]` API is preserved via `DatabaseRecordProxy`, which auto-persists to SQLite and emits `on_database_metadata_change` immediately on each write
- `databases.flush()` is deprecated (no-op with a `DeprecationWarning`)
- One-time automatic migration from `databases.json` on first access; original file kept as backup

## Design decisions

- **Naming**: `DatabaseRecord` (not `DatabaseMetadata`) — the table is the authoritative registry entry for a registered LCI database, not a secondary/auxiliary metadata store
- **Nullable columns**: all `DatabaseRecord` columns are `null=True`; a `NULL` value means "never explicitly set", matching the old JSON behaviour where absent keys meant the field was unset
- **Immediate signals**: `on_database_metadata_change` fires on each field write instead of being batched via `flush()`. Revision tests updated to reflect the now-finer-grained revision stream (geocollections gets its own revision during `write()`)
- **Signal suppression**: `make_searchable(signal=False)` / `make_unsearchable(signal=False)` set `databases._suppress_signals` so internal write-path operations don't create spurious revisions during revision replay
- **`version` field**: added to the "ignored" list in `revisions.py:database_metadata_change()` since it was never tracked before this change
- **`copy()` fix**: changed from `copy.copy(self.metadata)` to `dict(self.metadata)` to prevent mutations to the copy from writing through the shared proxy to the source database's row; `DatabaseRecordProxy.__copy__` returns a plain dict for the same reason
- **`JSONField` null handling**: `python_value()` now returns `None` for `NULL` columns instead of raising `TypeError`

## New public API

```python
from bw2data.backends.schema import DatabaseRecord

# Direct ORM access (new preferred style)
row = DatabaseRecord.get(DatabaseRecord.name == "my_db")
row.version += 1
row.save()

# Legacy dict-like access (still works, deprecated flush())
databases["my_db"]["geocollections"]          # reads from SQLite
databases["my_db"]["modified"] = "…"         # writes immediately, emits signal
```

## Test plan

- [x] Full test suite: `pytest tests/` — 179 passed, 0 failed
- [x] `databases.flush()` emits `DeprecationWarning` and is a no-op
- [x] Proxy writes auto-persist and emit `on_database_metadata_change`
- [x] `make_searchable(signal=False)` does not create revisions during write
- [x] Revision replay (`apply_revision`) works correctly with new metadata storage
- [x] Migration test path: project with existing `databases.json` migrates on first access